### PR TITLE
Add consignment without E-mail information

### DIFF
--- a/Tests/SendConsignments/SendOneConsignmentWithoutEmailTest.php
+++ b/Tests/SendConsignments/SendOneConsignmentWithoutEmailTest.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Test to check if a consignment without E-mail address is being submitted
+ *
+ * If you want to add improvements, please create a fork in our GitHub:
+ * https://github.com/myparcelnl
+ *
+ * @author      Reindert Vetter <reindert@myparcel.nl>
+ * @copyright   2010-2017 MyParcel
+ * @license     http://creativecommons.org/licenses/by-nc-nd/3.0/nl/deed.en_US  CC BY-NC-ND 3.0 NL
+ * @link        https://github.com/myparcelnl/sdk
+ * @since       File available since Release v0.1.0
+ */
+
+namespace myparcelnl\sdk\Tests\SendConsignments;
+
+
+use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
+use MyParcelNL\Sdk\src\Model\Repository\MyParcelConsignmentRepository;
+
+/**
+ * Class SendOneConsignmentWithoutEmailTest
+ * @package MyParcelNL\Sdk\tests\SendOneConsignmentWithoutEmailTest
+ */
+class SendOneConsignmentWithoutEmailTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test one shipment with createConcepts()
+     */
+    public function testSendOneConsignment()
+    {
+        foreach ($this->additionProvider() as $consignmentTest) {
+
+            $myParcelCollection = new MyParcelCollection();
+
+            $consignment = (new MyParcelConsignmentRepository())
+                ->setApiKey($consignmentTest['api_key'])
+                ->setCountry($consignmentTest['cc'])
+                ->setPerson($consignmentTest['person'])
+                ->setCompany($consignmentTest['company'])
+                ->setFullStreet($consignmentTest['full_street'])
+                ->setPostalCode($consignmentTest['postal_code'])
+                ->setCity($consignmentTest['city'])
+                ->setPhone($consignmentTest['phone'])
+                ->setPackageType($consignmentTest['package_type'])
+                ;
+
+            if (key_exists('label_description', $consignmentTest)) {
+                            $consignment->setLabelDescription($consignmentTest['label_description']);
+            }
+
+            $myParcelCollection->addConsignment($consignment);
+
+            /**
+             * Create concept
+             */
+            $myParcelCollection->createConcepts();
+
+            $this->assertEquals(true, $consignment->getMyParcelConsignmentId() > 1, 'No id found');
+            $this->assertEquals($consignmentTest['api_key'], $consignment->getApiKey(), 'getApiKey()');
+            $this->assertEquals($consignmentTest['cc'], $consignment->getCountry(), 'getCountry()');
+            $this->assertEquals($consignmentTest['person'], $consignment->getPerson(), 'getPerson()');
+            $this->assertEquals($consignmentTest['company'], $consignment->getCompany(), 'getCompany()');
+            $this->assertEquals($consignmentTest['full_street'], $consignment->getFullStreet(), 'getFullStreet()');
+            $this->assertEquals($consignmentTest['postal_code'], $consignment->getPostalCode(), 'getPostalCode()');
+            $this->assertEquals($consignmentTest['city'], $consignment->getCity(), 'getCity()');
+            $this->assertEquals($consignmentTest['phone'], $consignment->getPhone(), 'getPhone()');
+
+            if (key_exists('label_description', $consignmentTest)) {
+                            $this->assertEquals($consignmentTest['label_description'], $consignment->getLabelDescription(), 'getLabelDescription()');
+            }
+        }
+    }
+
+    /**
+     * Data for the test
+     * @return array
+     */
+    public function additionProvider()
+    {
+        return [
+            [
+                'api_key' => '94a98610ab9bf67a82873196c9ca688c601c179a',
+                'cc' => 'NL',
+                'person' => 'Piet',
+                'company' => 'Mega Store',
+                'full_street_test' => 'Koestraat 55',
+                'full_street' => 'Koestraat 55',
+                'street' => 'Koestraat',
+                'number' => 55,
+                'number_suffix' => '',
+                'postal_code' => '2231JE',
+                'city' => 'Katwijk',
+                'phone' => '123-45-235-435',
+                'package_type' => 1,
+                'large_format' => false,
+                'only_recipient' => false,
+                'signature' => false,
+                'return' => false,
+                'label_description' => 'Label description',
+            ],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,5 +25,10 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"
+    },
+    "autoload": {
+        "psr-4" : {
+            "MyParcelNL\\Sdk\\src\\" : "src/"
+        }
     }
 }

--- a/src/Model/MyParcelConsignment.php
+++ b/src/Model/MyParcelConsignment.php
@@ -94,7 +94,7 @@ class MyParcelConsignment extends MyParcelClassConstants
     /**
      * @var string
      */
-    private $email = null;
+    private $email = '';
 
     /**
      * @var string


### PR DESCRIPTION
This PR allows SDK users to push a consignment, if there is no E-mail address available, by defaulting to an empty string, instead of null.
Implements #6 