### PR TITLE
#80 links made with setlinkoflabels() always return a4 pdfs

### DIFF
--- a/Tests/SendConsignments/SendLargeFormatTest.php
+++ b/Tests/SendConsignments/SendLargeFormatTest.php
@@ -96,7 +96,7 @@ class SendLargeFormatTest extends \PHPUnit_Framework_TestCase
 
             /** @var MyParcelConsignmentRepository $consignment */
             $consignment = $myParcelCollection->getOneConsignment();
-            $this->assertEquals($consignmentTest['large_format_after_request'], $consignment->isLargeFormat(), 'error Large Fromat');
+            $this->assertEquals($consignmentTest['large_format_after_request'], $consignment->isLargeFormat(), 'error Large Format');
 
             /** @todo; clear consignment in MyParcelCollection */
         }

--- a/Tests/SendConsignments/SendMultipleConsignmentsTest.php
+++ b/Tests/SendConsignments/SendMultipleConsignmentsTest.php
@@ -13,8 +13,7 @@
  * @since       File available since Release v0.1.0
  */
 
-namespace MyParcelNL\Sdk\tests\SendConsignments\
-SendOneConsignmentTest;
+namespace MyParcelNL\Sdk\tests\SendConsignments\SendOneConsignmentTest;
 
 use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
 use MyParcelNL\Sdk\src\Model\MyParcelRequest;

--- a/Tests/SendConsignments/SendMultipleConsignmentsTest.php
+++ b/Tests/SendConsignments/SendMultipleConsignmentsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Test for split addresses from full street
+ * Create multiple consignments
  *
  * If you want to add improvements, please create a fork in our GitHub:
  * https://github.com/myparcelnl
@@ -22,15 +22,17 @@ use MyParcelNL\Sdk\src\Model\Repository\MyParcelConsignmentRepository;
 
 
 /**
- * Class SendOneConsignmentTest
+ * Class SendMultipleConsignmentsTest
  * @package MyParcelNL\Sdk\tests\SendConsignmentsTest
  */
 class SendMultipleConsignmentsTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
-     * Test one shipment with createConcepts()
+     * Create multiple shipments with createConcepts()
+     * @throws \Exception
      */
-    public function testSendOneConsignment()
+    public function testSendMultipleConsignments()
     {
         if (getenv('API_KEY') == null || getenv('API_KEY2') == null) {
             echo "\033[31m Set 2 MyParcel API-keys in 'Environment variables' before running UnitTest. Example: API_KEY=f8912fb260639db3b1ceaef2730a4b0643ff0c31 and API_KEY2=f8912fb260sert4564bdsafds45y6afasd7fdas\n\033[0m";

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -367,7 +367,7 @@ class MyParcelCollection
         /** If $positions is not false, set paper size to A4 */
         $this
             ->createConcepts()
-            ->setPosition($positions);
+            ->setLabelFormat($positions);
 
         $conceptIds = $this->getConsignmentIds($key);
 
@@ -409,7 +409,7 @@ class MyParcelCollection
         /** If $positions is not false, set paper size to A4 */
         $this
             ->createConcepts()
-            ->setPosition($positions);
+            ->setLabelFormat($positions);
         $conceptIds = $this->getConsignmentIds($key);
 
         if ($key) {
@@ -551,7 +551,7 @@ class MyParcelCollection
      *
      * @return $this
      */
-    private function setPosition($positions = 1)
+    private function setLabelFormat($positions = 1)
     {
         /** If $positions is not false, set paper size to A4 */
         if (is_numeric($positions)) {

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -29,7 +29,7 @@ class MyParcelCollection
 {
     const PREFIX_REFERENCE_ID = 'REFERENCE_ID_';
     const PREFIX_PDF_FILENAME = 'myparcel-label-';
-		const DEFAULT_A4_POSITION = 1;
+    const DEFAULT_A4_POSITION = 1;
 
     /**
      * @var MyParcelConsignmentRepository[]
@@ -164,14 +164,14 @@ class MyParcelCollection
         return $this;
     }
 
-	/**
-	 * @param \MyParcelNL\Sdk\src\Model\Repository\MyParcelConsignmentRepository $consignment
-	 *
-	 * @param bool $needReferenceId
-	 *
-	 * @return $this
-	 * @throws \Exception
-	 */
+    /**
+     * @param \MyParcelNL\Sdk\src\Model\Repository\MyParcelConsignmentRepository $consignment
+     *
+     * @param bool $needReferenceId
+     *
+     * @return $this
+     * @throws \Exception
+     */
     public function addConsignment(MyParcelConsignmentRepository $consignment, $needReferenceId = true)
     {
         if ($consignment->getApiKey() === null) {
@@ -180,9 +180,9 @@ class MyParcelCollection
 
         if ($needReferenceId && !empty($this->consignments)) {
             if ($consignment->getReferenceId() === null) {
-                    throw new \Exception('First set the reference id with setReferenceId() before running addConsignment() for multiple shipments');
+                throw new \Exception('First set the reference id with setReferenceId() before running addConsignment() for multiple shipments');
             } elseif (key_exists($consignment->getReferenceId(), $this->consignments)) {
-                    throw new \Exception('setReferenceId() must be unique. For example, do not use an ID of an order as an order has multiple shipments. In that case, use the shipment ID.');
+                throw new \Exception('setReferenceId() must be unique. For example, do not use an ID of an order as an order has multiple shipments. In that case, use the shipment ID.');
             }
         }
 
@@ -191,7 +191,7 @@ class MyParcelCollection
         } else {
             $this->consignments[] = $consignment;
         }
-        
+
         return $this;
     }
 
@@ -227,13 +227,13 @@ class MyParcelCollection
 
         return $this;
     }
-    
-        /**
-         * Delete concepts in MyParcel
-         *
-         * @return  $this
-         * @throws  \Exception
-         */
+
+    /**
+     * Delete concepts in MyParcel
+     *
+     * @return  $this
+     * @throws  \Exception
+     */
     public function deleteConcepts()
     {
         /* @var $consignments MyParcelConsignmentRepository[] */
@@ -255,16 +255,16 @@ class MyParcelCollection
         return $this;
     }
 
-	/**
-	 * Get all current data
-	 *
-	 * Set id and run this function to update all the information about this shipment
-	 *
-	 * @param int $size
-	 *
-	 * @return $this
-	 * @throws \Exception
-	 */
+    /**
+     * Get all current data
+     *
+     * Set id and run this function to update all the information about this shipment
+     *
+     * @param int $size
+     *
+     * @return $this
+     * @throws \Exception
+     */
     public function setLatestData($size = 300)
     {
         $consignmentIds = $this->getConsignmentIds($key);
@@ -312,20 +312,20 @@ class MyParcelCollection
         return $this;
     }
 
-	/**
-	 * Get all current data
-	 *
-	 * Set id and run this function to update all the information about this shipment
-	 *
-	 * @param $key
-	 * @param int $size
-	 *
-	 * @return $this
-	 * @throws \Exception
-	 */
+    /**
+     * Get all current data
+     *
+     * Set id and run this function to update all the information about this shipment
+     *
+     * @param $key
+     * @param int $size
+     *
+     * @return $this
+     * @throws \Exception
+     */
     public function setLatestDataWithoutIds($key, $size = 300)
     {
-	    $params = '?size=' . $size;
+        $params = '?size=' . $size;
 
         $request = (new MyParcelRequest())
             ->setUserAgent($this->getUserAgent())
@@ -341,11 +341,10 @@ class MyParcelCollection
         }
 
         foreach ($request->getResult()['data']['shipments'] as $shipment) {
-	        $consignment = new MyParcelConsignmentRepository();
+            $consignment = new MyParcelConsignmentRepository();
             $consignment->setApiKey($key)->apiDecode($shipment);
-	        $this->addConsignment($consignment, false);
+            $this->addConsignment($consignment, false);
         }
-
 
         return $this;
     }
@@ -353,11 +352,11 @@ class MyParcelCollection
     /**
      * Get link of labels
      *
-     * @param array|int|bool $positions The position of the label on an A4 sheet. Set to false to create an A6 sheet. You can specify multiple positions by
-     *                                  using an array. E.g. [2,3,4]. If you do not specify an array, but specify a
-     *                                  number, the following labels will fill the ascending positions. Positioning is
-     *                                  only applied on the first page with labels. All subsequent pages will use the
-     *                                  default positioning [1,2,3,4].
+     * @param array|int|bool $positions The position of the label on an A4 sheet. Set to false to create an A6 sheet.
+     *                                  You can specify multiple positions by using an array. E.g. [2,3,4]. If you do
+     *                                  not specify an array, but specify a number, the following labels will fill the
+     *                                  ascending positions. Positioning is only applied on the first page with labels.
+     *                                  All subsequent pages will use the default positioning [1,2,3,4].
      *
      * @return $this
      * @throws \Exception

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -454,7 +454,7 @@ class MyParcelCollection
     }
 
     /**
-     * Send return label to custommer. The customer can pay and download the label.
+     * Send return label to customer. The customer can pay and download the label.
      *
      * @throws \Exception
      * @return $this

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -366,7 +366,7 @@ class MyParcelCollection
         /** If $positions is not false, set paper size to A4 */
         $this
             ->createConcepts()
-            ->setA4($positions);
+            ->setPosition($positions);
 
         $conceptIds = $this->getConsignmentIds($key);
 
@@ -408,7 +408,7 @@ class MyParcelCollection
         /** If $positions is not false, set paper size to A4 */
         $this
             ->createConcepts()
-            ->setA4($positions);
+            ->setPosition($positions);
         $conceptIds = $this->getConsignmentIds($key);
 
         if ($key) {
@@ -550,7 +550,7 @@ class MyParcelCollection
      *
      * @return $this
      */
-    private function setA4($positions = 1)
+    private function setPosition($positions = 1)
     {
         /** If $positions is not false, set paper size to A4 */
         if (is_numeric($positions)) {

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -29,6 +29,7 @@ class MyParcelCollection
 {
     const PREFIX_REFERENCE_ID = 'REFERENCE_ID_';
     const PREFIX_PDF_FILENAME = 'myparcel-label-';
+		const DEFAULT_A4_POSITION = 1;
 
     /**
      * @var MyParcelConsignmentRepository[]
@@ -352,7 +353,7 @@ class MyParcelCollection
     /**
      * Get link of labels
      *
-     * @param array|int|bool $positions The position of the label on an A4 sheet. You can specify multiple positions by
+     * @param array|int|bool $positions The position of the label on an A4 sheet. Set to false to create an A6 sheet. You can specify multiple positions by
      *                                  using an array. E.g. [2,3,4]. If you do not specify an array, but specify a
      *                                  number, the following labels will fill the ascending positions. Positioning is
      *                                  only applied on the first page with labels. All subsequent pages will use the
@@ -361,7 +362,7 @@ class MyParcelCollection
      * @return $this
      * @throws \Exception
      */
-    public function setLinkOfLabels($positions = false)
+    public function setLinkOfLabels($positions = self::DEFAULT_A4_POSITION)
     {
         /** If $positions is not false, set paper size to A4 */
         $this
@@ -375,7 +376,7 @@ class MyParcelCollection
                 ->setUserAgent($this->getUserAgent())
                 ->setRequestParameters(
                     $key,
-                    implode(';', $conceptIds),
+                    implode(';', $conceptIds) . '/' . $this->getRequestBody(),
                     MyParcelRequest::REQUEST_HEADER_RETRIEVE_LABEL_LINK
                 )
                 ->sendRequest('GET', MyParcelRequest::REQUEST_TYPE_RETRIEVE_LABEL);

--- a/src/Model/MyParcelConsignment.php
+++ b/src/Model/MyParcelConsignment.php
@@ -32,7 +32,7 @@ class MyParcelConsignment
     const DATE_REGEX = '~(\d{4}-\d{2}-\d{2})$~';
     const DATE_TIME_REGEX = '~(\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2})$~';
     const STATUS_CONCEPT = 1;
-    const MAX_STREET_LENTH = 40;
+    const MAX_STREET_LENGTH = 40;
 
     const CC_NL = 'NL';
     const CC_BE = 'BE';
@@ -437,7 +437,7 @@ class MyParcelConsignment
      */
     public function getStreet($useStreetAdditionalInfo = false)
     {
-        if ($useStreetAdditionalInfo && strlen($this->street) >= self::MAX_STREET_LENTH) {
+        if ($useStreetAdditionalInfo && strlen($this->street) >= self::MAX_STREET_LENGTH) {
             $streetParts = $this->getStreetParts();
 
             return $streetParts[0];
@@ -1162,6 +1162,6 @@ class MyParcelConsignment
      */
     private function getStreetParts()
     {
-        return explode("\n", wordwrap($this->street, self::MAX_STREET_LENTH));
+        return explode("\n", wordwrap($this->street, self::MAX_STREET_LENGTH));
     }
 }

--- a/src/Model/MyParcelRequest.php
+++ b/src/Model/MyParcelRequest.php
@@ -212,7 +212,7 @@ class MyParcelRequest
             } elseif (key_exists('message', $error)) {
                 $message = $error['message'];
             } else {
-                $message = 'Unknow error: ' . json_encode($error) . '. Please contact MyParcel.';
+                $message = 'Unknown error: ' . json_encode($error) . '. Please contact MyParcel.';
             }
 
             if (key_exists('code', $error)) {


### PR DESCRIPTION
- rename setA4() to setPosition() because it can can create A6 as well depending on its argument
- send getRequestBody() with setLinkOfLabels() allowing it to create A6 pdfs. add constant DEFAULT_A4_POSITION = 1 as default value for $positions argument so it still creates A4 as default (useful for customers)