### PR TITLE
fix-support-collection-class 

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -515,7 +515,7 @@ class Collection extends CollectionProxy implements ArrayAccess, Countable, Iter
      * @param  mixed  $value
      * @return static
      */
-    public function where($key, $operator, $value = null)
+    public function where($key, $operator = null, $value = null)
     {
         return $this->filter($this->operatorForWhere(...func_get_args()));
     }
@@ -528,7 +528,7 @@ class Collection extends CollectionProxy implements ArrayAccess, Countable, Iter
      * @param  mixed  $value
      * @return \Closure
      */
-    protected function operatorForWhere($key, $operator, $value = null)
+    protected function operatorForWhere($key, $operator = null, $value = null)
     {
         if (func_num_args() === 2) {
             $value = $operator;


### PR DESCRIPTION
Operator for where and operatorForWhere should be NULL by default according to the Laravel 5.7 documentation (https://laravel.com/api/5.7/Illuminate/Support/Collection.html)

It generated and error when trying to install or use the SDK package because of the mismatch.