### PR TITLE
FirstWhere $operator = null needs to be set for Laravel 5.8 support

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -666,7 +666,7 @@ class Collection extends CollectionProxy implements ArrayAccess, Countable, Iter
      * @param  mixed  $value
      * @return static
      */
-    public function firstWhere($key, $operator, $value = null)
+    public function firstWhere($key, $operator = null, $value = null)
     {
         return $this->first($this->operatorForWhere(...func_get_args()));
     }


### PR DESCRIPTION
FirstWhere Operator also needs a default of NULL to support Laravel 5.8

https://laravel.com/docs/5.8/upgrade#upgrade-5.8.0

> The firstWhere Method
> Likelihood Of Impact: Very Low
> 
> The firstWhere method signature has changed to match the where method's signature. If you are overriding this method, you should update the method signature to match its parent:
> 

```
/**
 * Get the first item by the given key value pair.
 *
 * @param  string  $key
 * @param  mixed  $operator
 * @param  mixed  $value
 * @return mixed
 */
public function firstWhere($key, $operator = null, $value = null);
```