### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $myParcelCollection = (new MyParcelCollection())
     ->addConsignment($consignment)
     ->setPdfOfLabels();
 
-$consignmentId = $myParcelCollection->first()->getMyParcelConsignmentId();
+$consignmentId = $myParcelCollection->first()->getConsignmentId();
 
 $myParcelCollection->downloadPdfOfLabels();
 ```
@@ -315,7 +315,7 @@ $consignment
     ->getBarcode() // Barcode is available after using setLinkOfLabels() or setPdfOfLabels() on the MyParcelCollection the consignment has been added to
     
     ->getLabelDescription()
-    ->getMyParcelConsignmentId()
+    ->getConsignmentId()
     ->getShopId()
     ->getStatus()
     

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ You can download the zip on the project's [releases page](https://github.com/myp
 ## Quick start and examples
 Add the following lines to your project to import the SDK classes for creating shipments.
 ```php
-use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
 use MyParcelNL\Sdk\src\Factory\ConsignmentFactory;
+use MyParcelNL\Sdk\src\Helper\MyParcelCollection;
 use MyParcelNL\Sdk\src\Model\Consignment\PostNLConsignment;
 ```
 


### PR DESCRIPTION
It is my understanding that `getMyParcelConsignmentId()` is depricated as of v3 and is replaced with `getConsignmentId()`?
I did not dive in the code, but this is what PHPstorm suggested...
Please validate if line 79 is correct as well prior to merging.