### PR TITLE
Fix for Uncaught TypeError: strlen() expects parameter 1 to be string

### DIFF
--- a/src/Model/Consignment/AbstractConsignment.php
+++ b/src/Model/Consignment/AbstractConsignment.php
@@ -695,6 +695,9 @@ class AbstractConsignment
      */
     public function getStreet($useStreetAdditionalInfo = false)
     {
+        if (null === $this->street) {
+            $this->street = '';
+        }
         if ($useStreetAdditionalInfo && strlen($this->street) >= self::MAX_STREET_LENGTH) {
             $streetParts = SplitStreet::getStreetParts($this->street);
 


### PR DESCRIPTION
Fatal error: Uncaught TypeError: strlen() expects parameter 1 to be string, null given in vendor/myparcelnl/sdk/src/Model/Consignment/AbstractConsignment.php:703