### PR TITLE
Compatible with Laravel 7

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -479,11 +479,11 @@ class Collection extends CollectionProxy implements ArrayAccess, Countable, Iter
      * Apply the callback if the value is truthy.
      *
      * @param  bool  $value
-     * @param  callable  $callback
-     * @param  callable  $default
+     * @param  callable|null  $callback
+     * @param  callable|null  $default
      * @return mixed
      */
-    public function when($value, callable $callback, callable $default = null)
+    public function when($value, callable $callback = null, callable $default = null)
     {
         if ($value) {
             return $callback($this, $value);


### PR DESCRIPTION
Fixes:
PHP Fatal error:  Declaration of MyParcelNL\Sdk\src\Support\Collection::when($value, callable $callback, ?callable $default = NULL) must be compatible with Illuminate\Support\Collection::when($value, ?callable $callback = NULL, ?callable $default = NULL) in /vendor/myparcelnl/sdk/src/Support/Collection.php on line 38