### PR TITLE
fix fatal on missing destination country regex

### DIFF
--- a/src/Helper/ValidateStreet.php
+++ b/src/Helper/ValidateStreet.php
@@ -36,7 +36,12 @@ class ValidateStreet
      */
     public static function validate(string $fullStreet, string $localCountry, ?string $destinationCountry): bool
     {
-        $result = preg_match(ValidateStreet::getStreetRegexByCountry($localCountry, $destinationCountry), $fullStreet, $matches);
+        $regex = ValidateStreet::getStreetRegexByCountry($localCountry, $destinationCountry);
+        if (null === $regex) {
+            return false;
+        }
+        
+        $result = preg_match($regex, $fullStreet, $matches);
 
         if (! $result || ! is_array($matches)) {
             // Invalid full street supplied


### PR DESCRIPTION
Fix
Fatal Error: 'Uncaught TypeError: preg_match() expects parameter 1 to be string, null given in /..../vendor/myparcelnl/sdk/src/Helper/ValidateStreet.php:39