### PR TITLE
Fix receiving shopId, fix error when null values are allowed

### DIFF
--- a/src/Adapter/ConsignmentAdapter.php
+++ b/src/Adapter/ConsignmentAdapter.php
@@ -63,6 +63,7 @@ class ConsignmentAdapter
         /** @noinspection PhpInternalEntityUsedInspection */
         $this->consignment
             ->setConsignmentId($this->data['id'])
+            ->setShopId($this->data['shop_id'])
             ->setReferenceId($this->data['reference_identifier'])
             ->setBarcode($this->data['barcode'])
             ->setStatus($this->data['status'])

--- a/src/Model/Consignment/AbstractConsignment.php
+++ b/src/Model/Consignment/AbstractConsignment.php
@@ -586,7 +586,7 @@ class AbstractConsignment
     /**
      * @return integer|null
      */
-    public function getShopId(): ?int
+    public function getShopId(): int
     {
         return $this->shop_id;
     }

--- a/src/Model/Consignment/AbstractConsignment.php
+++ b/src/Model/Consignment/AbstractConsignment.php
@@ -586,7 +586,7 @@ class AbstractConsignment
     /**
      * @return integer|null
      */
-    public function getShopId(): int
+    public function getShopId(): ?int
     {
         return $this->shop_id;
     }
@@ -1577,7 +1577,7 @@ class AbstractConsignment
     /**
      * @return string|null
      */
-    public function getPickupStreet(): string
+    public function getPickupStreet(): ?string
     {
         return $this->pickup_street;
     }
@@ -1601,7 +1601,7 @@ class AbstractConsignment
     /**
      * @return string|null
      */
-    public function getPickupCity(): string
+    public function getPickupCity(): ?string
     {
         return $this->pickup_city;
     }
@@ -1625,7 +1625,7 @@ class AbstractConsignment
     /**
      * @return string|null
      */
-    public function getPickupNumber(): string
+    public function getPickupNumber(): ?string
     {
         return $this->pickup_number;
     }


### PR DESCRIPTION
This pull requests fixes setting shop_id to consignment when receiving it from api

it also fixes when values of a consignment are NULL. it did already show in comments that NULL was allowed, but not in declaration of function so it did give errors when it was NULL. 

