### PR TITLE
fix: show correct internatioanal errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "myparcelnl/sdk",
-    "version": "v5.2.4",
+    "version": "v5.2.5",
     "description": "This package is designed to send and receive data from MyParcel by means of an API.",
     "homepage": "https://www.myparcel.nl",
     "keywords": ["MyParcel", "My Parcel", "Flespakket", "Post NL", "PostNL"],

--- a/src/Services/ConsignmentEncode.php
+++ b/src/Services/ConsignmentEncode.php
@@ -291,12 +291,12 @@ class ConsignmentEncode
             throw new MissingFieldException('Product data must be set for international MyParcel shipments. Use addItem().');
         }
 
-        if ($consignment->getPackageType() !== AbstractConsignment::PACKAGE_TYPE_PACKAGE) {
-            throw new MissingFieldException('For international shipments, package_type must be 1 (normal package).');
+        if ($consignment->getPackageType() !== AbstractConsignment::PACKAGE_TYPE_PACKAGE && $consignment->getPackageType() !== AbstractConsignment::PACKAGE_TYPE_LETTER) {
+            throw new MissingFieldException('For international shipments, package_type must be 1 (normal package) or 3 (letter).');
         }
 
-        if (empty($consignment->getLabelDescription())) {
-            throw new MissingFieldException('Label description/invoice id is required for international shipments. Use getLabelDescription().');
+        if (empty($consignment->getInvoice())) {
+            throw new MissingFieldException('Invoice id is required for international shipments. Use setInvoice().');
         }
     }
 


### PR DESCRIPTION
It is also possible to send letters for an international shipment.
A label description is not required, but an invoice id is required.