### PR TITLE
Fix: the shipment options must be null if they do not exist

### DIFF
--- a/src/Adapter/DeliveryOptions/ShipmentOptionsV3Adapter.php
+++ b/src/Adapter/DeliveryOptions/ShipmentOptionsV3Adapter.php
@@ -4,8 +4,6 @@ namespace MyParcelNL\Sdk\src\Adapter\DeliveryOptions;
 
 class ShipmentOptionsV3Adapter extends AbstractShipmentOptionsAdapter
 {
-    private const DEFAULT_INSURANCE = 0;
-
     /**
      * @param array $shipmentOptions
      */
@@ -13,7 +11,7 @@ class ShipmentOptionsV3Adapter extends AbstractShipmentOptionsAdapter
     {
         $this->signature         = $shipmentOptions["signature"] ?? null;
         $this->only_recipient    = $shipmentOptions["only_recipient"] ?? null;
-        $this->insurance         = $shipmentOptions["insurance"] ?? self::DEFAULT_INSURANCE;
+        $this->insurance         = $shipmentOptions["insurance"] ?? null;
         $this->age_check         = $shipmentOptions["age_check"] ?? null;
         $this->large_format      = $shipmentOptions["large_format"] ?? null;
         $this->return            = $shipmentOptions["return"] ?? null;

--- a/src/Adapter/DeliveryOptions/ShipmentOptionsV3Adapter.php
+++ b/src/Adapter/DeliveryOptions/ShipmentOptionsV3Adapter.php
@@ -11,12 +11,12 @@ class ShipmentOptionsV3Adapter extends AbstractShipmentOptionsAdapter
      */
     public function __construct(array $shipmentOptions)
     {
-        $this->signature         = $shipmentOptions["signature"] ?? false;
-        $this->only_recipient    = $shipmentOptions["only_recipient"] ?? false;
+        $this->signature         = $shipmentOptions["signature"] ?? null;
+        $this->only_recipient    = $shipmentOptions["only_recipient"] ?? null;
         $this->insurance         = $shipmentOptions["insurance"] ?? self::DEFAULT_INSURANCE;
         $this->age_check         = $shipmentOptions["age_check"] ?? null;
-        $this->large_format      = $shipmentOptions["large_format"] ?? false;
-        $this->return            = $shipmentOptions["return"] ?? false;
+        $this->large_format      = $shipmentOptions["large_format"] ?? null;
+        $this->return            = $shipmentOptions["return"] ?? null;
         $this->label_description = $shipmentOptions["label_description"] ?? null;
     }
 }


### PR DESCRIPTION
- If you don't get a value from the delivery option you want to use null instead of false.