### PR TITLE
My 28141 show friendlier error messages

### DIFF
--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -4,4 +4,34 @@ namespace MyParcelNL\Sdk\src\Exception;
 
 class ApiException extends \Exception
 {
+    public function __construct($message = null, $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+
+        $this->message = $this->parseMessageForHumans($this->getMessage());
+    }
+
+    protected function parseMessageForHumans(string $original_error_message): string
+    {
+        $index       = (int) (explode('.shipments[', $original_error_message)[1] ?? -1);
+        if (-1 === $index) {
+            return $original_error_message;
+        }
+        $api_message = explode(' Shipment validation error ', $original_error_message)[0];
+        $request_str = '{' . explode('Request: {', $original_error_message)[1] ?? '}';
+        $request_obj = json_decode($request_str, null);
+        if (isset($request_obj->data, $request_obj->data->shipments[$index])) {
+            $shipments   = $request_obj->data->shipments;
+            $order_id    = $shipments[$index]->reference_identifier;
+            $order_count = (string) count($shipments);
+        }
+        ob_start();
+        printf('<strong>API refused %s shipments</strong><br/>', $order_count ?? 'these');
+        if (isset($order_id)) {
+            printf('Error for order id %s. ', $order_id);
+        }
+        echo 'Original message from API:<br/>';
+        echo $api_message;
+        return ob_get_clean();
+    }
 }

--- a/src/Model/Consignment/AbstractConsignment.php
+++ b/src/Model/Consignment/AbstractConsignment.php
@@ -9,6 +9,7 @@ use MyParcelNL\Sdk\src\Exception\MissingFieldException;
 use MyParcelNL\Sdk\src\Helper\SplitStreet;
 use MyParcelNL\Sdk\src\Helper\TrackTraceUrl;
 use MyParcelNL\Sdk\src\Helper\ValidatePostalCode;
+use MyParcelNL\Sdk\src\Helper\ValidateStreet;
 use MyParcelNL\Sdk\src\Model\MyParcelCustomsItem;
 use MyParcelNL\Sdk\src\Support\Helpers;
 
@@ -1811,9 +1812,23 @@ class AbstractConsignment
 
     /**
      * @return bool
+     * @throws \MyParcelNL\Sdk\src\Exception\MissingFieldException
      */
     public function validate(): bool
     {
+        $country = $this->getCountry();
+        if (! $country)
+        {
+            throw new MissingFieldException('Missing country');
+        }
+        if (! ValidatePostalCode::validate($this->getPostalCode(), $country))
+        {
+            throw new MissingFieldException('Invalid postal code');
+        }
+        if (in_array($country, [self::CC_BE, self::CC_NL]) && ! $this->getNumber())
+        {
+            throw new MissingFieldException('Missing number');
+        }
         return true;
     }
 }


### PR DESCRIPTION
By actually validating some basic data it is easier to prevent bulk errors through the api, in addition any error thrown by the api is parsed especially to try to get the actual offending order_id to feedback to the client.