### PR TITLE
fix: use method to get the request url

### DIFF
--- a/Tests/SendConsignments/SendMultipleConsignmentsTest.php
+++ b/Tests/SendConsignments/SendMultipleConsignmentsTest.php
@@ -66,7 +66,7 @@ class SendMultipleConsignmentsTest extends TestCase
 
         $this->assertEquals(
             true,
-            preg_match("#^" . MyParcelRequest::REQUEST_URL . "/pdfs#", $myParcelCollection->getLinkOfLabels()),
+            preg_match("#^" . (new MyParcelRequest())->getRequestUrl() . "/pdfs#", $myParcelCollection->getLinkOfLabels()),
             'Can\'t get link of PDF'
         );
 

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -425,7 +425,7 @@ class MyParcelCollection extends Collection
                 )
                 ->sendRequest('GET', $requestType);
 
-            $this->label_link = (new MyParcelRequest())->getRequestUrl(). $request->getResult("data.$urlLocation.url");
+            $this->label_link = (new MyParcelRequest())->getRequestUrl() . $request->getResult("data.$urlLocation.url");
         }
 
         $this->setLatestData();

--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -425,7 +425,7 @@ class MyParcelCollection extends Collection
                 )
                 ->sendRequest('GET', $requestType);
 
-            $this->label_link = MyParcelRequest::REQUEST_URL . $request->getResult("data.$urlLocation.url");
+            $this->label_link = (new MyParcelRequest())->getRequestUrl(). $request->getResult("data.$urlLocation.url");
         }
 
         $this->setLatestData();


### PR DESCRIPTION
If you want to connect the plugins to a staging, it is possible to adjust the API_BASE_URL (in the plugin). Only an adjustment has to be made in the sdk to actually get the label from staging.