### PR TITLE
add php8 tests in travis + fix php 8.1 Deprecated warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,9 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
+    - php: 7.4
+    - php: 8.0
+    - php: 8.1
     - php: nightly
 
 sudo: false

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -1778,6 +1778,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return \ArrayIterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator()
     {
         return new ArrayIterator($this->items);
@@ -1799,6 +1800,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->items);
@@ -1820,6 +1822,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      * @param  mixed  $key
      * @return bool
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($key)
     {
         return array_key_exists($key, $this->items);
@@ -1831,6 +1834,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      * @param  mixed  $key
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($key)
     {
         return $this->items[$key];
@@ -1843,6 +1847,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      * @param  mixed  $value
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($key, $value)
     {
         if (is_null($key)) {
@@ -1858,6 +1863,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
      * @param  string  $key
      * @return void
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($key)
     {
         unset($this->items[$key]);


### PR DESCRIPTION
Fix php8.1 errors in Collection.php

got these errors

```
PHP Deprecated:  Return type of MyParcelNL\Sdk\src\Support\Collection::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1823

Deprecated: Return type of MyParcelNL\Sdk\src\Support\Collection::offsetExists($key) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1823
PHP Deprecated:  Return type of MyParcelNL\Sdk\src\Support\Collection::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1834

Deprecated: Return type of MyParcelNL\Sdk\src\Support\Collection::offsetGet($key) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1834
PHP Deprecated:  Return type of MyParcelNL\Sdk\src\Support\Collection::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1846

Deprecated: Return type of MyParcelNL\Sdk\src\Support\Collection::offsetSet($key, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1846
PHP Deprecated:  Return type of MyParcelNL\Sdk\src\Support\Collection::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1861

Deprecated: Return type of MyParcelNL\Sdk\src\Support\Collection::offsetUnset($key) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1861
PHP Deprecated:  Return type of MyParcelNL\Sdk\src\Support\Collection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1802

Deprecated: Return type of MyParcelNL\Sdk\src\Support\Collection::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1802
PHP Deprecated:  Return type of MyParcelNL\Sdk\src\Support\Collection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1781

Deprecated: Return type of MyParcelNL\Sdk\src\Support\Collection::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /Users/test/Desktop/sdk/src/Support/Collection.php on line 1781
```