### PR TITLE
feat: add international bbp

### DIFF
--- a/src/Model/Account/CarrierOptions.php
+++ b/src/Model/Account/CarrierOptions.php
@@ -29,6 +29,10 @@ class CarrierOptions extends BaseModel
      * @var bool
      */
     private $optional;
+    /**
+     * @var string
+     */
+    private $type;
 
     /**
      * @param  array $options
@@ -41,6 +45,7 @@ class CarrierOptions extends BaseModel
         $this->optional = (bool) $options['optional'];
         $this->carrier  = CarrierFactory::create($options['carrier']['id']);
         $this->label    = $options['label'] ?? $this->carrier->getHuman();
+        $this->type     = $options['type'] ?? $this->label;
     }
 
     /**
@@ -57,6 +62,14 @@ class CarrierOptions extends BaseModel
     public function getLabel(): string
     {
         return $this->label;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType(): string
+    {
+        return $this->type;
     }
 
     /**

--- a/test/Model/Account/CarrierOptionsTest.php
+++ b/test/Model/Account/CarrierOptionsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Model\Account;
+
+use MyParcelNL\Sdk\src\Model\Account\CarrierOptions;
+use MyParcelNL\Sdk\src\Model\Carrier\CarrierDPD;
+use MyParcelNL\Sdk\src\Model\Carrier\CarrierPostNL;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+class CarrierOptionsTest extends TestCase
+{
+    public function testCarrierOptions(): void
+    {
+        foreach ($this->provideTestData() as $testData) {
+            $carrierOptions = new CarrierOptions($testData['options']);
+            $expected = $testData['expected'];
+
+            self::assertEquals($expected['enabled'], $carrierOptions->isEnabled());
+            self::assertEquals($expected['optional'], $carrierOptions->isOptional());
+            self::assertEquals($expected['type'], $carrierOptions->getType());
+            self::assertEquals($expected['label'], $carrierOptions->getLabel());
+            self::assertInstanceOf($expected['carrier'], $carrierOptions->getCarrier());
+        }
+    }
+
+    /**
+     * @return \Generator
+     */
+    private function provideTestData()
+    {
+        $option_collections = [
+            ['options' => [
+                'enabled' => true,
+                'optional' => true,
+                'carrier' => [
+                    'id' => 1,
+                ],
+                'label' => NULL,
+                'type' => 'main',
+            ],
+                'expected' => [
+                    'enabled' => true,
+                    'optional' => true,
+                    'carrier' => CarrierPostNL::class,
+                    'label' => CarrierPostNL::HUMAN,
+                    'type' => 'main',
+
+                ]
+            ],
+            ['options' => [
+                'enabled' => false,
+                'optional' => false,
+                'carrier' => [
+                    'id' => 4,
+                ],
+                'label' => 'custom',
+                'type' => 'custom',
+            ],
+                'expected' => [
+                    'enabled' => false,
+                    'optional' => false,
+                    'carrier' => CarrierDPD::class,
+                    'label' => 'custom',
+                    'type' => 'custom',
+
+                ]
+            ],
+        ];
+
+        foreach ($option_collections as $options) {
+            yield $options;
+        }
+    }
+}


### PR DESCRIPTION
International BBP is active for carrier PostNL with type `custom`, exposing the type through the SDK enables implementing the required logic.

INT-354
