### PR TITLE
fix: allow ark3 as number suffix

### DIFF
--- a/src/Helper/ValidateStreet.php
+++ b/src/Helper/ValidateStreet.php
@@ -17,8 +17,8 @@ class ValidateStreet
         '\s' .                              // Separator between street and number
         '(?P<number>\d{1,5})' .             // Number can contain a maximum of 5 numbers
         '[/\s\-]{0,2}' .                    // Separators between number and addition
-        '(?P<number_suffix>' .
-        '[a-z]{1}[/\-]?\d{1,3}|' .          // Numbers suffix starts with a letter with optional - or / followed by numbers or
+        '(?P<number_suffix>' .              // Number Suffix
+        '[a-z][/\-\da-z]{1,5}|' .           // starts with a letter, followed by numbers, letters, - or / with a maximum of 5 chars or
         '-\d{1,4}|' .                       // starts with - and has up to 4 numbers or
         '(?=.{2,6}$)\d{1,6}[/\-a-z]{1,5}|'. // starts with numbers followed by letters with a maximum of 6 chars, or
         '[a-z][a-z\s]{0,5}'.                // has up to 6 letters with a space

--- a/test/Model/Consignment/ConsignmentSplitStreetTest.php
+++ b/test/Model/Consignment/ConsignmentSplitStreetTest.php
@@ -24,6 +24,13 @@ class ConsignmentSplitStreetTest extends ConsignmentTestCase
     {
         return $this->createConsignmentProviderDataset([
             [
+                self::FULL_STREET                => 'Oosteinderweg 97 Ark3',
+                self::expected(self::FULL_STREET)   => 'Oosteinderweg 97 Ark3',
+                self::expected(self::STREET)        => 'Oosteinderweg',
+                self::expected(self::NUMBER)        => 97,
+                self::expected(self::NUMBER_SUFFIX) => 'Ark3',
+            ],
+            [
                 self::FULL_STREET                 => 'Graan voor Visch 19905',
                 self::expected(self::FULL_STREET) => 'Graan voor Visch 19905',
                 self::expected(self::STREET)      => 'Graan voor Visch',


### PR DESCRIPTION
Following a support request.
