### PR TITLE
fix: allow multishop in collections for export

### DIFF
--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -774,6 +774,33 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
     }
 
     /**
+     * Group this collection into separate collections by one or more fields.
+     * Returns an array of separate collections grouped by md5 encoded string of the grouped fields.
+     *
+     * @param array $by
+     * @return array
+     */
+    public function groupInto(array $by): array {
+        $result = [];
+
+        foreach ($this->items as $item) {
+            $group = '';
+            foreach ($by as $key) {
+                $group .= $this->helper->data_get($item, $key);
+            }
+            $group = md5($group);
+
+            if (!isset($result[$group])) {
+                $result[$group] = new static();
+            }
+
+            $result[$group]->push($item);
+        }
+
+        return $result;
+    }
+
+    /**
      * Key an associative array by a field or using a callback.
      *
      * @param  callable|string  $keyBy

--- a/src/Support/Collection.php
+++ b/src/Support/Collection.php
@@ -775,17 +775,16 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
 
     /**
      * Group this collection into separate collections by one or more fields.
-     * Returns an array of separate collections grouped by md5 encoded string of the grouped fields.
      *
-     * @param array $by
-     * @return array
+     * @param array $fields
+     * @return Collection of collections grouped by md5 encoded concatenated field values.
      */
-    public function groupInto(array $by): array {
+    public function groupInto(array $fields): self {
         $result = [];
 
         foreach ($this->items as $item) {
             $group = '';
-            foreach ($by as $key) {
+            foreach ($fields as $key) {
                 $group .= $this->helper->data_get($item, $key);
             }
             $group = md5($group);
@@ -797,7 +796,7 @@ class Collection implements ArrayAccess, Countable, IteratorAggregate
             $result[$group]->push($item);
         }
 
-        return $result;
+        return new static($result);
     }
 
     /**

--- a/test/Support/CollectionTest.php
+++ b/test/Support/CollectionTest.php
@@ -57,4 +57,148 @@ class CollectionTest extends TestCase
     {
         self::assertSame(((new Collection($input))->toArrayWithoutNull()), $output);
     }
+
+    public function testGroupBy(): void
+    {
+        $collection = new Collection([
+             ['a' => 1, 'b' => 'appel', 'c' => 'broccoli'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'wortel'],
+             ['a' => 2, 'b' => 'banaan', 'c' => 'bloemkool'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'spinazie'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'bloemkool'],
+             ['a' => 1, 'b' => 'peer', 'c' => 'wortel'],
+             ['a' => 2, 'b' => 'appel', 'c' => 'spinazie'],
+             ['a' => 2, 'b' => 'banaan', 'c' => 'broccoli'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'broccoli'],
+             ['a' => 3, 'b' => 'appel', 'c' => 'bloemkool'],
+        ]);
+
+        $grouped = $collection->groupBy(function ($item) {
+            return $item['a'];
+        });
+
+        self::assertSame(
+            [
+                1 => [
+                    ['a' => 1, 'b' => 'appel', 'c' => 'broccoli'],
+                    ['a' => 1, 'b' => 'peer', 'c' => 'wortel'],
+                ],
+                3 => [
+                    ['a' => 3, 'b' => 'peer', 'c' => 'wortel'],
+                    ['a' => 3, 'b' => 'peer', 'c' => 'spinazie'],
+                    ['a' => 3, 'b' => 'peer', 'c' => 'bloemkool'],
+                    ['a' => 3, 'b' => 'peer', 'c' => 'broccoli'],
+                    ['a' => 3, 'b' => 'appel', 'c' => 'bloemkool'],
+                ],
+                2 => [
+                    ['a' => 2, 'b' => 'banaan', 'c' => 'bloemkool'],
+                    ['a' => 2, 'b' => 'appel', 'c' => 'spinazie'],
+                    ['a' => 2, 'b' => 'banaan', 'c' => 'broccoli'],
+                ],
+            ],
+            $grouped->toArray()
+        );
+    }
+
+    public function testGroupInto(): void
+    {
+        $collection = new Collection([
+             ['a' => 1, 'b' => 'appel', 'c' => 'broccoli'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'wortel'],
+             ['a' => 2, 'b' => 'banaan', 'c' => 'bloemkool'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'spinazie'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'bloemkool'],
+             ['a' => 1, 'b' => 'peer', 'c' => 'wortel'],
+             ['a' => 2, 'b' => 'appel', 'c' => 'spinazie'],
+             ['a' => 2, 'b' => 'banaan', 'c' => 'broccoli'],
+             ['a' => 3, 'b' => 'peer', 'c' => 'broccoli'],
+             ['a' => 3, 'b' => 'appel', 'c' => 'bloemkool'],
+        ]);
+
+        $grouped = $collection->groupInto(['a', 'b']);
+
+        self::assertSame(
+            array (
+                'afb29a44c64418a0507392632ee9b911' =>
+                    array (
+                        0 =>
+                            array (
+                                'a' => 1,
+                                'b' => 'appel',
+                                'c' => 'broccoli',
+                            ),
+                    ),
+                '830ad1465ba6193bdc926b5aa4f4663a' =>
+                    array (
+                        0 =>
+                            array (
+                                'a' => 3,
+                                'b' => 'peer',
+                                'c' => 'wortel',
+                            ),
+                        1 =>
+                            array (
+                                'a' => 3,
+                                'b' => 'peer',
+                                'c' => 'spinazie',
+                            ),
+                        2 =>
+                            array (
+                                'a' => 3,
+                                'b' => 'peer',
+                                'c' => 'bloemkool',
+                            ),
+                        3 =>
+                            array (
+                                'a' => 3,
+                                'b' => 'peer',
+                                'c' => 'broccoli',
+                            ),
+                    ),
+                'fc2554ed6a4a01fe6decc2687f976d1a' =>
+                    array (
+                        0 =>
+                            array (
+                                'a' => 2,
+                                'b' => 'banaan',
+                                'c' => 'bloemkool',
+                            ),
+                        1 =>
+                            array (
+                                'a' => 2,
+                                'b' => 'banaan',
+                                'c' => 'broccoli',
+                            ),
+                    ),
+                'c301ad1cc996740d20ce50b40ce5701e' =>
+                    array (
+                        0 =>
+                            array (
+                                'a' => 1,
+                                'b' => 'peer',
+                                'c' => 'wortel',
+                            ),
+                    ),
+                '63f9062403bd4ea9414cbfaf5a957c36' =>
+                    array (
+                        0 =>
+                            array (
+                                'a' => 2,
+                                'b' => 'appel',
+                                'c' => 'spinazie',
+                            ),
+                    ),
+                '3f68cd66281efed34673d0c7c4a38c86' =>
+                    array (
+                        0 =>
+                            array (
+                                'a' => 3,
+                                'b' => 'appel',
+                                'c' => 'bloemkool',
+                            ),
+                    ),
+            ),
+            $grouped->toArray()
+        );
+    }
 }


### PR DESCRIPTION
With a new method on the collection (`->groupInto(['field1','field2'])`) provide the behaviour that the plugins expect from groupBy, ie the collections are split in fully separate collections in a collection.

INT-804
