### PR TITLE
fix: use sender for unrelated return

### DIFF
--- a/src/Model/Consignment/AbstractConsignment.php
+++ b/src/Model/Consignment/AbstractConsignment.php
@@ -1231,22 +1231,12 @@ abstract class AbstractConsignment
 
     /**
      * @param  array $consignmentEncoded
-     * @param  bool  $splitStreet todo remove once the API accepts full street for unrelated returns
      *
      * @return array
      * @throws \MyParcelNL\Sdk\src\Exception\MissingFieldException
      */
-    public function encodeStreet(array $consignmentEncoded, bool $splitStreet = false): array
+    public function encodeStreet(array $consignmentEncoded): array
     {
-        if ($splitStreet) {
-            $consignmentEncoded['recipient']['street'] = $this->getStreet(true);
-            $consignmentEncoded['recipient']['number'] = $this->getNumber();
-            $consignmentEncoded['recipient']['number_suffix'] = $this->getNumberSuffix();
-            $consignmentEncoded['recipient']['box_number'] = $this->getBoxNumber();
-            $consignmentEncoded['recipient']['street_additional_info'] = $this->getStreetAdditionalInfo();
-
-            return $consignmentEncoded;
-        }
         $consignmentEncoded['recipient']['street']                 = $this->getFullStreet(true);
         $consignmentEncoded['recipient']['street_additional_info'] = $this->getStreetAdditionalInfo();
 

--- a/src/Services/CollectionEncode.php
+++ b/src/Services/CollectionEncode.php
@@ -43,7 +43,14 @@ class CollectionEncode
         $groupedConsignments = $this->groupMultiColloConsignments();
 
         foreach ($groupedConsignments as $consignments) {
-            $data['data'][$key][] = (new ConsignmentEncode($consignments))->apiEncode('return_shipments' === $key);
+            $consignment = (new ConsignmentEncode($consignments))->apiEncode();
+            // switch original recipient to sender for return shipments
+            if ('return_shipments' === $key) {
+                $consignment['sender'] = $consignment['recipient'];
+                // API does not allow state for sender
+                unset($consignment['recipient'], $consignment['sender']['state']);
+            }
+            $data['data'][$key][] = $consignment;
         }
 
         // Remove \\n because json_encode encode \\n for \s

--- a/src/Services/ConsignmentEncode.php
+++ b/src/Services/ConsignmentEncode.php
@@ -50,15 +50,13 @@ class ConsignmentEncode
     /**
      * Encode all the data before sending it to MyParcel
      *
-     * @param  bool $splitStreet todo remove this once the API accepts the street as a single field
-     *
      * @return array
      * @throws \MyParcelNL\Sdk\src\Exception\MissingFieldException
      */
-    public function apiEncode(bool $splitStreet = false): array
+    public function apiEncode(): array
     {
         $this->encodeBase()
-             ->encodeStreet($splitStreet);
+             ->encodeStreet();
 
         $this->consignmentEncoded = self::encodeExtraOptions(
             $this->consignmentEncoded,
@@ -224,14 +222,13 @@ class ConsignmentEncode
     }
 
     /**
-     * @param  bool $splitStreet todo remove once the API accepts the street as a single field
      *
      * @return self
      */
-    private function encodeStreet(bool $splitStreet): self
+    private function encodeStreet(): self
     {
         $consignment              = Arr::first($this->consignments);
-        $this->consignmentEncoded = $consignment->encodeStreet($this->consignmentEncoded, $splitStreet);
+        $this->consignmentEncoded = $consignment->encodeStreet($this->consignmentEncoded);
 
         return $this;
     }


### PR DESCRIPTION
Also removes $splitStreet flag for that issue is resolved by using sender rather than recipient.

INT-912
