### PR TITLE
fix: Check for both NL and BE and correct the insurance value by converting to cents

### DIFF
--- a/src/Services/ConsignmentEncode.php
+++ b/src/Services/ConsignmentEncode.php
@@ -132,9 +132,9 @@ class ConsignmentEncode
         if (AbstractConsignment::PACKAGE_TYPE_PACKAGE_SMALL === $consignment->getPackageType()) {
             $consignmentEncoded['options']['large_format'] = 0;
 
-            if (AbstractConsignment::CC_NL !== $consignment->getCountry()
+            if (!in_array($consignment->getCountry(), [AbstractConsignment::CC_NL, AbstractConsignment::CC_BE])
                 && self::MAX_INSURANCE_PACKETS_ROW < $consignment->getInsurance() * 100) {
-                $consignmentEncoded['options']['insurance']['amount'] = self::MAX_INSURANCE_PACKETS_ROW;
+                $consignmentEncoded['options']['insurance']['amount'] = self::MAX_INSURANCE_PACKETS_ROW * 100;
             }
 
             if (in_array($consignment->getCountry(), [AbstractConsignment::CC_NL, AbstractConsignment::CC_BE])) {


### PR DESCRIPTION
## Summary 🌟
This PR will fix the insurance value when creating a small package in accordance as to how the MyParcel Dashboard allows you to create and change parcels.

## Technical choices ⚙️

- Added an `in_array` check for both `CC_NL` and `CC_BE` before applying the 5k minimum insurance rule
- Fixed the 5k insurance amount applied when creating an EU consignment

## Testing instructions 📚

You can test this PR by following these steps:

1. Create a parcel with insurance value under 5k
2. Navigate to the [shipments page](https://backoffice.myparcel.nl/shipments?page=1) and observe that the parcel has been correctly made with the intended insurance value.

---

In this screenshot you see 3 scenario's.
1. This is with current code. Where insurance value for any country except `CC_NL` is set to 5 EUR. Resulting in a parcel with an insurance value (as created by the API) of 100 EUR.
3. The second is correcting the insurance value to the what I think intended 5k value, creating my `CC_BE` parcel with 5K even though with the dashboard other options are possible.
4. Only apply the rule for countries other than `CC_NL` or `CC_BE` giving the desired functionality that seems inline with how the dashboard is able to handle things.

<img width="1456" height="357" alt="image" src="https://github.com/user-attachments/assets/1cc7602d-38bf-4f8f-b88e-4d54507d89fa" />
