### PR TITLE
fix: prevent api error retail network id null value found

### DIFF
--- a/src/Services/ConsignmentEncode.php
+++ b/src/Services/ConsignmentEncode.php
@@ -251,8 +251,10 @@ class ConsignmentEncode
                 'number'            => $consignment->getPickupNumber(),
                 'location_name'     => $consignment->getPickupLocationName(),
                 'location_code'     => $consignment->getPickupLocationCode(),
-                'retail_network_id' => $consignment->getRetailNetworkId(),
             ];
+            if (($retailNetworkId = $consignment->getRetailNetworkId())) {
+                $this->consignmentEncoded['pickup']['retail_network_id'] = $retailNetworkId;
+            }
         }
 
         $this->consignmentEncoded['general_settings']['save_recipient_address']     = $this->normalizeAutoSaveRecipientAddress($consignment);


### PR DESCRIPTION
This error is also returned when we send an empty string, therefore don’t add the retail network id if there is nothing meaningful in it.
