### PR TITLE
fix: return correct shipment by api key

### DIFF
--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -116,10 +116,6 @@ class MyParcelCollection extends Collection
             throw new InvalidArgumentException('Can\'t run getConsignmentsByReferenceId() because referenceId can\'t be null');
         }
 
-        if ($this->count() === 1) {
-            return new static($this->items);
-        }
-
         return $this->where('reference_identifier', $id);
     }
 


### PR DESCRIPTION
INT-1242
While returning the only shipment upon a query by api key may seem like a good shortcut, this returns always this (incorrect) shipment on collections where all shipments fail but one.
