### PR TITLE
fix: return multicollo correctly

### DIFF
--- a/src/Helper/MyParcelCollection.php
+++ b/src/Helper/MyParcelCollection.php
@@ -223,7 +223,7 @@ class MyParcelCollection extends Collection
         }
 
         // Set multi collo and reference identifier for all consignments
-        $referenceId = $consignments[0]->getReferenceIdentifier() ?: ('multi_collo_' . uniqid('', true));
+        $referenceId = $consignments[0]->getReferenceIdentifier() ?: 'multi_collo_' . uniqid('', true);
         foreach ($consignments as $consignment) {
             $consignment->setMultiCollo(true);
             $consignment->setReferenceIdentifier($referenceId);

--- a/test/Helper/MyParcelCollectionTest.php
+++ b/test/Helper/MyParcelCollectionTest.php
@@ -396,4 +396,29 @@ class MyParcelCollectionTest extends CollectionTestCase
         }
     }
 
+    public function testSetLatestDataThrowsExceptionWhenNoShipments(): void
+    {
+        $collection = $this->generateCollection(
+            $this->createConsignmentsTestData([
+                [self::REFERENCE_IDENTIFIER => 'no_shipments_test'],
+            ])
+        );
+
+        $curlMock = $this->mockCurl();
+
+        $curlMock->shouldReceive('write')->once();
+        $curlMock->shouldReceive('getResponse')
+            ->once()
+            ->andReturn([
+                'response' => json_encode(['data' => []]), // No 'shipments' key
+                'code'     => 200,
+            ]);
+        $curlMock->shouldReceive('close')->once();
+
+        $this->expectException(\MyParcelNL\Sdk\Exception\ApiException::class);
+        $this->expectExceptionMessage('Unknown Error in MyParcel API response');
+
+        $collection->setLatestData();
+    }
+
 }


### PR DESCRIPTION
INT-1251

Also ensures
- total weight in grams is an integer, preventing useless errors being thrown in case of float
- multicollo is exported correctly for consignments with an empty string as reference id (rather than null)
