### PR TITLE
feat: introduce label- and track & trace services for shipment domain

### DIFF
--- a/src/Services/CoreApi/ShipmentApiFactory.php
+++ b/src/Services/CoreApi/ShipmentApiFactory.php
@@ -155,14 +155,6 @@ final class ShipmentApiFactory
             }
 
             $trackTrace = array_intersect_key($trackTrace, array_flip($allowedTrackTraceKeys));
-
-            if (isset($trackTrace['carrier'])) {
-                $carrier = $trackTrace['carrier'];
-
-                if (is_string($carrier) && ctype_digit($carrier)) {
-                    $trackTrace['carrier'] = (int) $carrier;
-                }
-            }
         }
         unset($trackTrace);
 

--- a/src/Services/CoreApi/ShipmentApiFactory.php
+++ b/src/Services/CoreApi/ShipmentApiFactory.php
@@ -156,8 +156,12 @@ final class ShipmentApiFactory
 
             $trackTrace = array_intersect_key($trackTrace, array_flip($allowedTrackTraceKeys));
 
-            if (isset($trackTrace['carrier']) && is_int($trackTrace['carrier'])) {
-                $trackTrace['carrier'] = (string) $trackTrace['carrier'];
+            if (isset($trackTrace['carrier'])) {
+                $carrier = $trackTrace['carrier'];
+
+                if (is_string($carrier) && ctype_digit($carrier)) {
+                    $trackTrace['carrier'] = (int) $carrier;
+                }
             }
         }
         unset($trackTrace);

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Services\Labels;
+
+use InvalidArgumentException;
+use MyParcelNL\Sdk\Concerns\HasUserAgent;
+use MyParcelNL\Sdk\Exception\ApiException;
+use MyParcelNL\Sdk\Exception\MissingFieldException;
+use MyParcelNL\Sdk\Helper\LabelHelper;
+use MyParcelNL\Sdk\Model\MyParcelRequest;
+use setasign\Fpdi\Fpdi;
+
+final class ShipmentLabelsService
+{
+    use HasUserAgent;
+
+    private const PREFIX_PDF_FILENAME = 'myparcel-label-';
+
+    private string $apiKey;
+
+    private string $labelLink = '';
+
+    private string $labelPdf = '';
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @param int[] $shipmentIds
+     * @param mixed $positions
+     */
+    public function setLinkOfLabels(array $shipmentIds, $positions = 1): string
+    {
+        $this->validateIds($shipmentIds);
+
+        $queryString = $this->buildLabelQuery($positions);
+        $urlLocation = 'pdfs';
+        $requestType = MyParcelRequest::REQUEST_TYPE_RETRIEVE_LABEL;
+
+        if ($this->useLabelPrepare(count($shipmentIds))) {
+            $requestType = MyParcelRequest::REQUEST_TYPE_RETRIEVE_PREPARED_LABEL;
+            $urlLocation = 'pdf';
+        }
+
+        $request = (new MyParcelRequest())
+            ->setUserAgents($this->getUserAgent())
+            ->setRequestParameters(
+                $this->apiKey,
+                implode(';', $shipmentIds) . '/' . $queryString
+            )
+            ->sendRequest('GET', $requestType);
+
+        $this->labelLink = (new MyParcelRequest())->getRequestUrl() . $request->getResult("data.{$urlLocation}.url");
+
+        return $this->labelLink;
+    }
+
+    public function getLinkOfLabels(): string
+    {
+        return $this->labelLink;
+    }
+
+    /**
+     * @param int[] $shipmentIds
+     * @param mixed $positions
+     *
+     * @throws ApiException
+     */
+    public function setPdfOfLabels(array $shipmentIds, $positions = 1): string
+    {
+        $this->validateIds($shipmentIds);
+
+        $queryString = $this->buildLabelQuery($positions);
+
+        $request = (new MyParcelRequest())
+            ->setUserAgents($this->getUserAgent())
+            ->setRequestParameters(
+                $this->apiKey,
+                implode(';', $shipmentIds) . '/' . $queryString,
+                MyParcelRequest::HEADER_ACCEPT_APPLICATION_PDF
+            )
+            ->sendRequest('GET', MyParcelRequest::REQUEST_TYPE_RETRIEVE_LABEL);
+
+        $result = $request->getResult();
+
+        if (! is_string($result) || ! preg_match('/^%PDF-\d/', $result)) {
+            if (is_array($result) && isset($result['data']['payment_instructions'])) {
+                throw new ApiException('Received payment link instead of pdf. Check your MyParcel account status.');
+            }
+
+            throw new ApiException('Did not receive expected pdf response. Please contact MyParcel.');
+        }
+
+        if (! class_exists(Fpdi::class)) {
+            throw new ApiException('FPDI dependency is required to process label PDFs.');
+        }
+
+        $fpdi = new Fpdi();
+        $fileResource = fopen('php://memory', 'rb+');
+        fwrite($fileResource, $result);
+
+        $pageCount = $fpdi->setSourceFile($fileResource);
+
+        for ($i = 1; $i <= $pageCount; $i++) {
+            $templateIndex = $fpdi->importPage($i);
+            $specs = $fpdi->getTemplateSize($templateIndex);
+            $fpdi->addPage($specs['orientation'], [$specs['width'], $specs['height']]);
+            $fpdi->useTemplate($templateIndex);
+        }
+
+        $this->labelPdf = $fpdi->Output('S');
+
+        fclose($fileResource);
+
+        return $this->labelPdf;
+    }
+
+    public function getLabelPdf(): string
+    {
+        return $this->labelPdf;
+    }
+
+    /**
+     * @throws MissingFieldException
+     */
+    public function downloadPdfOfLabels(bool $inlineDownload = false): void
+    {
+        if ('' === $this->labelPdf) {
+            throw new MissingFieldException('First set label_pdf key with setPdfOfLabels() before running downloadPdfOfLabels()');
+        }
+
+        header('Content-Type: application/pdf');
+        header('Content-Length: ' . strlen($this->labelPdf));
+        header('Content-disposition: ' . ($inlineDownload ? 'inline' : 'attachment') . '; filename="' . self::PREFIX_PDF_FILENAME . gmdate('Y-M-d H-i-s') . '.pdf"');
+        header('Cache-Control: public, must-revalidate, max-age=0');
+        header('Pragma: public');
+        header('Expires: Sat, 26 Jul 1997 05:00:00 GMT');
+        header('Last-Modified: ' . gmdate('D, d M Y H:i:s') . ' GMT');
+
+        echo $this->labelPdf;
+        exit;
+    }
+
+    public function useLabelPrepare(int $numberOfShipments): bool
+    {
+        return $numberOfShipments > MyParcelRequest::SHIPMENT_LABEL_PREPARE_ACTIVE_FROM;
+    }
+
+    /**
+     * @param mixed $positions
+     */
+    private function buildLabelQuery($positions): string
+    {
+        if (is_numeric($positions)) {
+            return '?format=A4&positions=' . LabelHelper::getPositions((int) $positions);
+        }
+
+        if (is_array($positions)) {
+            return '?format=A4&positions=' . implode(';', $positions);
+        }
+
+        return '?format=A6';
+    }
+
+    /**
+     * @param array<int, mixed> $ids
+     */
+    private function validateIds(array $ids): void
+    {
+        if (empty($ids)) {
+            throw new InvalidArgumentException('At least one shipment ID is required');
+        }
+
+        foreach ($ids as $id) {
+            if (! is_int($id) && ! (is_string($id) && ctype_digit($id))) {
+                throw new InvalidArgumentException('Shipment IDs must be integers');
+            }
+        }
+    }
+}

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -18,6 +18,10 @@ use setasign\Fpdi\Fpdi;
 
 /**
  * Service for retrieving shipment labels (link/PDF) by shipment IDs.
+ *
+ * @todo Temporary workaround: use generated request-builder + manual sendRequest()
+ *       because generated ShipmentApi::getShipmentsLabels() currently exposes a void return flow.
+ *       Replace with direct generated response handling once spec/generator returns typed label body.
  */
 final class ShipmentLabelsService
 {

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -4,66 +4,73 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Sdk\Services\Labels;
 
+use GuzzleHttp\Client as GuzzleClient;
 use InvalidArgumentException;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Exception\ApiException;
 use MyParcelNL\Sdk\Exception\MissingFieldException;
 use MyParcelNL\Sdk\Helper\LabelHelper;
 use MyParcelNL\Sdk\Model\MyParcelRequest;
+use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 use setasign\Fpdi\Fpdi;
 
 /**
  * Service for retrieving shipment labels (link/PDF) by shipment IDs.
- *
- * Intentionally uses MyParcelRequest for now:
- * - generated ShipmentApi::getShipmentsLabels() currently returns no response body,
- *   while this service needs to read label URLs and raw PDF bytes.
- * - prepared labels endpoint (/v2/shipment_labels/{ids}) is not covered by the
- *   generated ShipmentApi operation set.
  */
 final class ShipmentLabelsService
 {
     use HasUserAgent;
 
     private const PREFIX_PDF_FILENAME = 'myparcel-label-';
+    private const LABEL_LINK_ACCEPT_HEADER = 'application/vnd.shipment_label_link+json';
+    private const PDF_ACCEPT_HEADER = 'application/pdf';
 
-    private string $apiKey;
+    private ShipmentApi $api;
+    private ClientInterface $httpClient;
 
     private string $labelLink = '';
 
     private string $labelPdf = '';
 
-    public function __construct(string $apiKey)
-    {
-        $this->apiKey = $apiKey;
+    public function __construct(
+        string $apiKey,
+        ?ShipmentApi $api = null,
+        ?ClientInterface $httpClient = null,
+        ?string $host = null
+    ) {
+        $this->api = $api ?? ShipmentApiFactory::make($apiKey, $host);
+        $this->httpClient = $httpClient ?? new GuzzleClient(['timeout' => 10]);
     }
 
     /**
      * @param int[] $shipmentIds
      * @param mixed $positions
+     *
+     * @throws ApiException
      */
     public function setLinkOfLabels(array $shipmentIds, $positions = 1): string
     {
         $this->validateIds($shipmentIds);
 
-        $queryString = $this->buildLabelQuery($positions);
-        $urlLocation = 'pdfs';
-        $requestType = MyParcelRequest::REQUEST_TYPE_RETRIEVE_LABEL;
+        [$format, $resolvedPositions] = $this->resolveFormatAndPositions($positions);
+        $request = $this->buildLabelsRequest($shipmentIds, $format, $resolvedPositions)
+            ->withHeader('Accept', self::LABEL_LINK_ACCEPT_HEADER);
+        $response = $this->httpClient->sendRequest($request);
 
-        if ($this->useLabelPrepare(count($shipmentIds))) {
-            $requestType = MyParcelRequest::REQUEST_TYPE_RETRIEVE_PREPARED_LABEL;
-            $urlLocation = 'pdf';
+        $decoded = json_decode((string) $response->getBody(), true);
+        if (! is_array($decoded)) {
+            throw new ApiException('Did not receive expected label link response. Please contact MyParcel.');
         }
 
-        $request = (new MyParcelRequest())
-            ->setUserAgents($this->getUserAgent())
-            ->setRequestParameters(
-                $this->apiKey,
-                implode(';', $shipmentIds) . '/' . $queryString
-            )
-            ->sendRequest('GET', $requestType);
+        $url = $decoded['data']['pdfs']['url'] ?? $decoded['data']['pdf']['url'] ?? null;
+        if (! is_string($url) || '' === $url) {
+            throw new ApiException('Did not receive expected label link response. Please contact MyParcel.');
+        }
 
-        $this->labelLink = (new MyParcelRequest())->getRequestUrl() . $request->getResult("data.{$urlLocation}.url");
+        $this->labelLink = $this->resolveAbsoluteUrl($url, $request);
 
         return $this->labelLink;
     }
@@ -83,21 +90,15 @@ final class ShipmentLabelsService
     {
         $this->validateIds($shipmentIds);
 
-        $queryString = $this->buildLabelQuery($positions);
-
-        $request = (new MyParcelRequest())
-            ->setUserAgents($this->getUserAgent())
-            ->setRequestParameters(
-                $this->apiKey,
-                implode(';', $shipmentIds) . '/' . $queryString,
-                MyParcelRequest::HEADER_ACCEPT_APPLICATION_PDF
-            )
-            ->sendRequest('GET', MyParcelRequest::REQUEST_TYPE_RETRIEVE_LABEL);
-
-        $result = $request->getResult();
+        [$format, $resolvedPositions] = $this->resolveFormatAndPositions($positions);
+        $request = $this->buildLabelsRequest($shipmentIds, $format, $resolvedPositions)
+            ->withHeader('Accept', self::PDF_ACCEPT_HEADER);
+        $response = $this->httpClient->sendRequest($request);
+        $result = (string) $response->getBody();
 
         if (! is_string($result) || ! preg_match('/^%PDF-\d/', $result)) {
-            if (is_array($result) && isset($result['data']['payment_instructions'])) {
+            $decoded = json_decode($result, true);
+            if (is_array($decoded) && isset($decoded['data']['payment_instructions'])) {
                 throw new ApiException('Received payment link instead of pdf. Check your MyParcel account status.');
             }
 
@@ -154,25 +155,63 @@ final class ShipmentLabelsService
         exit;
     }
 
+    /**
+     * @deprecated Prepared labels are handled by the regular labels endpoint using Accept negotiation.
+     *             This method remains for backward compatibility.
+     */
     public function useLabelPrepare(int $numberOfShipments): bool
     {
         return $numberOfShipments > MyParcelRequest::SHIPMENT_LABEL_PREPARE_ACTIVE_FROM;
     }
 
     /**
-     * @param mixed $positions
+     * Build label request using generated ShipmentApi request builder.
+     *
+     * @param int[] $shipmentIds
      */
-    private function buildLabelQuery($positions): string
+    private function buildLabelsRequest(array $shipmentIds, string $format, ?string $positions): RequestInterface
+    {
+        return $this->api->getShipmentsLabelsRequest(
+            implode(';', array_map('strval', $shipmentIds)),
+            $this->getUserAgentHeader(),
+            $format,
+            $positions,
+            null,
+            null,
+            ShipmentApi::contentTypes['getShipmentsLabels'][0]
+        );
+    }
+
+    /**
+     * @param mixed $positions
+     * @return array{0: string, 1: string|null}
+     */
+    private function resolveFormatAndPositions($positions): array
     {
         if (is_numeric($positions)) {
-            return '?format=A4&positions=' . LabelHelper::getPositions((int) $positions);
+            return ['A4', LabelHelper::getPositions((int) $positions)];
         }
 
         if (is_array($positions)) {
-            return '?format=A4&positions=' . implode(';', $positions);
+            return ['A4', implode(';', $positions)];
         }
 
-        return '?format=A6';
+        return ['A6', null];
+    }
+
+    private function resolveAbsoluteUrl(string $url, RequestInterface $request): string
+    {
+        if (preg_match('/^https?:\/\//i', $url)) {
+            return $url;
+        }
+
+        $uri = $request->getUri();
+        $base = $uri->getScheme() . '://' . $uri->getHost();
+        if (null !== $uri->getPort()) {
+            $base .= ':' . $uri->getPort();
+        }
+
+        return rtrim($base, '/') . '/' . ltrim($url, '/');
     }
 
     /**

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -12,6 +12,15 @@ use MyParcelNL\Sdk\Helper\LabelHelper;
 use MyParcelNL\Sdk\Model\MyParcelRequest;
 use setasign\Fpdi\Fpdi;
 
+/**
+ * Service for retrieving shipment labels (link/PDF) by shipment IDs.
+ *
+ * Intentionally uses MyParcelRequest for now:
+ * - generated ShipmentApi::getShipmentsLabels() currently returns no response body,
+ *   while this service needs to read label URLs and raw PDF bytes.
+ * - prepared labels endpoint (/v2/shipment_labels/{ids}) is not covered by the
+ *   generated ShipmentApi operation set.
+ */
 final class ShipmentLabelsService
 {
     use HasUserAgent;

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -14,7 +14,6 @@ use MyParcelNL\Sdk\Model\MyParcelRequest;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
-use setasign\Fpdi\Fpdi;
 
 /**
  * Service for retrieving shipment labels (link/PDF) by shipment IDs.
@@ -104,26 +103,7 @@ final class ShipmentLabelsService
             throw new ApiException('Did not receive expected pdf response. Please contact MyParcel.');
         }
 
-        if (! class_exists(Fpdi::class)) {
-            throw new ApiException('FPDI dependency is required to process label PDFs.');
-        }
-
-        $fpdi = new Fpdi();
-        $fileResource = fopen('php://memory', 'rb+');
-        fwrite($fileResource, $result);
-
-        $pageCount = $fpdi->setSourceFile($fileResource);
-
-        for ($i = 1; $i <= $pageCount; $i++) {
-            $templateIndex = $fpdi->importPage($i);
-            $specs = $fpdi->getTemplateSize($templateIndex);
-            $fpdi->addPage($specs['orientation'], [$specs['width'], $specs['height']]);
-            $fpdi->useTemplate($templateIndex);
-        }
-
-        $this->labelPdf = $fpdi->Output('S');
-
-        fclose($fileResource);
+        $this->labelPdf = $result;
 
         return $this->labelPdf;
     }

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace MyParcelNL\Sdk\Services\Labels;
 
 use GuzzleHttp\Client as GuzzleClient;
-use InvalidArgumentException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Exception\ApiException;
@@ -26,7 +25,7 @@ final class ShipmentLabelsService
 
     private const PREFIX_PDF_FILENAME = 'myparcel-label-';
     private const LABEL_LINK_ACCEPT_HEADER = 'application/vnd.shipment_label_link+json';
-    private const PDF_ACCEPT_HEADER = 'application/pdf';
+    private const PDF_ACCEPT_HEADER = 'application/pdf+print';
 
     private ShipmentApi $api;
     private ClientInterface $httpClient;
@@ -53,8 +52,6 @@ final class ShipmentLabelsService
      */
     public function setLinkOfLabels(array $shipmentIds, $positions = 1): string
     {
-        $this->validateIds($shipmentIds);
-
         [$format, $resolvedPositions] = $this->resolveFormatAndPositions($positions);
         $request = $this->buildLabelsRequest($shipmentIds, $format, $resolvedPositions)
             ->withHeader('Accept', self::LABEL_LINK_ACCEPT_HEADER);
@@ -88,8 +85,6 @@ final class ShipmentLabelsService
      */
     public function setPdfOfLabels(array $shipmentIds, $positions = 1): string
     {
-        $this->validateIds($shipmentIds);
-
         [$format, $resolvedPositions] = $this->resolveFormatAndPositions($positions);
         $request = $this->buildLabelsRequest($shipmentIds, $format, $resolvedPositions)
             ->withHeader('Accept', self::PDF_ACCEPT_HEADER);
@@ -212,21 +207,5 @@ final class ShipmentLabelsService
         }
 
         return rtrim($base, '/') . '/' . ltrim($url, '/');
-    }
-
-    /**
-     * @param array<int, mixed> $ids
-     */
-    private function validateIds(array $ids): void
-    {
-        if (empty($ids)) {
-            throw new InvalidArgumentException('At least one shipment ID is required');
-        }
-
-        foreach ($ids as $id) {
-            if (! is_int($id) && ! (is_string($id) && ctype_digit($id))) {
-                throw new InvalidArgumentException('Shipment IDs must be integers');
-            }
-        }
     }
 }

--- a/src/Services/TrackTrace/ShipmentTrackTraceService.php
+++ b/src/Services/TrackTrace/ShipmentTrackTraceService.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Services\TrackTrace;
+
+use InvalidArgumentException;
+use MyParcelNL\Sdk\Concerns\HasUserAgent;
+use MyParcelNL\Sdk\Model\MyParcelRequest;
+
+final class ShipmentTrackTraceService
+{
+    use HasUserAgent;
+
+    private string $apiKey;
+
+    public function __construct(string $apiKey)
+    {
+        $this->apiKey = $apiKey;
+    }
+
+    /**
+     * @param int[] $shipmentIds
+     * @return array<int, array<string, mixed>>
+     */
+    public function fetchTrackTraceData(array $shipmentIds): array
+    {
+        if (empty($shipmentIds)) {
+            throw new InvalidArgumentException('At least one shipment ID is required');
+        }
+
+        $uri = 'tracktraces/' . implode(';', $shipmentIds);
+
+        $request = (new MyParcelRequest())
+            ->setUserAgents($this->getUserAgent())
+            ->setRequestParameters($this->apiKey)
+            ->sendRequest('GET', $uri);
+
+        $trackTraces = $request->getResult('data.tracktraces') ?? [];
+
+        if (! is_array($trackTraces)) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($trackTraces as $trackTrace) {
+            if (! is_array($trackTrace) || ! isset($trackTrace['shipment_id'])) {
+                continue;
+            }
+
+            $result[(int) $trackTrace['shipment_id']] = $trackTrace;
+        }
+
+        return $result;
+    }
+}

--- a/src/Services/TrackTrace/ShipmentTrackTraceService.php
+++ b/src/Services/TrackTrace/ShipmentTrackTraceService.php
@@ -5,23 +5,26 @@ declare(strict_types=1);
 namespace MyParcelNL\Sdk\Services\TrackTrace;
 
 use InvalidArgumentException;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsTrackTrace;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesTracktraces;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
-use MyParcelNL\Sdk\Model\MyParcelRequest;
+use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
 
 final class ShipmentTrackTraceService
 {
     use HasUserAgent;
 
-    private string $apiKey;
+    private ShipmentApi $api;
 
-    public function __construct(string $apiKey)
+    public function __construct(string $apiKey, ?ShipmentApi $api = null, ?string $baseUri = null)
     {
-        $this->apiKey = $apiKey;
+        $this->api = $api ?? ShipmentApiFactory::make($apiKey, $baseUri);
     }
 
     /**
      * @param int[] $shipmentIds
-     * @return array<int, array<string, mixed>>
+     * @return array<int, ShipmentDefsTrackTrace>
      */
     public function fetchTrackTraceData(array $shipmentIds): array
     {
@@ -29,27 +32,33 @@ final class ShipmentTrackTraceService
             throw new InvalidArgumentException('At least one shipment ID is required');
         }
 
-        $uri = 'tracktraces/' . implode(';', $shipmentIds);
+        $response = $this->api->getTrackTracesByIds(
+            implode(';', $shipmentIds),
+            $this->getUserAgentHeader()
+        );
 
-        $request = (new MyParcelRequest())
-            ->setUserAgents($this->getUserAgent())
-            ->setRequestParameters($this->apiKey)
-            ->sendRequest('GET', $uri);
+        return $this->mapTrackTracesByShipmentId($response);
+    }
 
-        $trackTraces = $request->getResult('data.tracktraces') ?? [];
+    /**
+     * @return array<int, ShipmentDefsTrackTrace>
+     */
+    private function mapTrackTracesByShipmentId(ShipmentResponsesTracktraces $response): array
+    {
+        $data = $response->getData();
 
-        if (! is_array($trackTraces)) {
+        if (null === $data || ! is_array($data->getTracktraces())) {
             return [];
         }
 
         $result = [];
 
-        foreach ($trackTraces as $trackTrace) {
-            if (! is_array($trackTrace) || ! isset($trackTrace['shipment_id'])) {
+        foreach ($data->getTracktraces() as $trackTrace) {
+            if (! $trackTrace instanceof ShipmentDefsTrackTrace) {
                 continue;
             }
 
-            $result[(int) $trackTrace['shipment_id']] = $trackTrace;
+            $result[(int) $trackTrace->getShipmentId()] = $trackTrace;
         }
 
         return $result;

--- a/test/Services/CoreApi/ShipmentApiFactoryTest.php
+++ b/test/Services/CoreApi/ShipmentApiFactoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Services\CoreApi;
+
+use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+use ReflectionMethod;
+
+final class ShipmentApiFactoryTest extends TestCase
+{
+    public function testNormalizeShipmentRequestPayloadCastsNumericEnumStrings(): void
+    {
+        $payload = [
+            'data' => [
+                'shipments' => [
+                    [
+                        'carrier' => '1',
+                        'options' => [
+                            'package_type' => '2',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $normalized = $this->invokeFactoryNormalizer('normalizeShipmentRequestPayload', $payload);
+
+        self::assertIsInt($normalized['data']['shipments'][0]['carrier']);
+        self::assertSame(1, $normalized['data']['shipments'][0]['carrier']);
+        self::assertIsInt($normalized['data']['shipments'][0]['options']['package_type']);
+        self::assertSame(2, $normalized['data']['shipments'][0]['options']['package_type']);
+    }
+
+    public function testNormalizeTrackTraceResponsePayloadKeepsStableFieldsOnly(): void
+    {
+        $payload = [
+            'data' => [
+                'tracktraces' => [
+                    [
+                        'shipment_id' => 123,
+                        'carrier' => 1,
+                        'code' => 'delivered',
+                        'description' => 'Delivered',
+                        'time' => '2026-02-24T09:00:00+00:00',
+                        'link_consumer_portal' => 'https://consumer',
+                        'link_tracktrace' => 'https://track',
+                        'delayed' => false,
+                        'returnable' => true,
+                        // Known problematic nested structures for generated deserializer.
+                        'recipient' => ['email' => 'user@example.com', 'street' => 'Main'],
+                        'sender' => ['email' => 'sender@example.com'],
+                        'options' => ['package_type' => 1],
+                    ],
+                ],
+            ],
+        ];
+
+        $normalized = $this->invokeFactoryNormalizer('normalizeTrackTraceResponsePayload', $payload);
+        $trackTrace = $normalized['data']['tracktraces'][0];
+
+        self::assertSame(
+            [
+                'shipment_id',
+                'carrier',
+                'code',
+                'description',
+                'time',
+                'link_consumer_portal',
+                'link_tracktrace',
+                'delayed',
+                'returnable',
+            ],
+            array_keys($trackTrace)
+        );
+        self::assertIsString($trackTrace['carrier']);
+        self::assertSame('1', $trackTrace['carrier']);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @return array<string, mixed>
+     */
+    private function invokeFactoryNormalizer(string $method, array $payload): array
+    {
+        $reflection = new ReflectionMethod(ShipmentApiFactory::class, $method);
+        $reflection->setAccessible(true);
+
+        /** @var array<string, mixed> $normalized */
+        $normalized = $reflection->invoke(null, $payload);
+
+        return $normalized;
+    }
+}

--- a/test/Services/CoreApi/ShipmentApiFactoryTest.php
+++ b/test/Services/CoreApi/ShipmentApiFactoryTest.php
@@ -10,27 +10,21 @@ use ReflectionMethod;
 
 final class ShipmentApiFactoryTest extends TestCase
 {
-    public function testNormalizeShipmentRequestPayloadCastsNumericEnumStrings(): void
+    public function testNormalizeTrackTraceResponsePayloadNormalizesCarrierValues(): void
     {
         $payload = [
             'data' => [
-                'shipments' => [
-                    [
-                        'carrier' => '1',
-                        'options' => [
-                            'package_type' => '2',
-                        ],
-                    ],
+                'tracktraces' => [
+                    ['carrier' => '1'],
+                    ['carrier' => 2],
                 ],
             ],
         ];
 
-        $normalized = $this->invokeFactoryNormalizer('normalizeShipmentRequestPayload', $payload);
+        $normalized = $this->invokeFactoryNormalizer('normalizeTrackTraceResponsePayload', $payload);
 
-        self::assertIsInt($normalized['data']['shipments'][0]['carrier']);
-        self::assertSame(1, $normalized['data']['shipments'][0]['carrier']);
-        self::assertIsInt($normalized['data']['shipments'][0]['options']['package_type']);
-        self::assertSame(2, $normalized['data']['shipments'][0]['options']['package_type']);
+        self::assertSame(1, $normalized['data']['tracktraces'][0]['carrier']);
+        self::assertSame(2, $normalized['data']['tracktraces'][1]['carrier']);
     }
 
     public function testNormalizeTrackTraceResponsePayloadKeepsStableFieldsOnly(): void
@@ -74,8 +68,8 @@ final class ShipmentApiFactoryTest extends TestCase
             ],
             array_keys($trackTrace)
         );
-        self::assertIsString($trackTrace['carrier']);
-        self::assertSame('1', $trackTrace['carrier']);
+        self::assertIsInt($trackTrace['carrier']);
+        self::assertSame(1, $trackTrace['carrier']);
     }
 
     /**
@@ -85,7 +79,10 @@ final class ShipmentApiFactoryTest extends TestCase
     private function invokeFactoryNormalizer(string $method, array $payload): array
     {
         $reflection = new ReflectionMethod(ShipmentApiFactory::class, $method);
-        $reflection->setAccessible(true);
+
+        if (PHP_VERSION_ID < 80100) {
+            $reflection->setAccessible(true);
+        }
 
         /** @var array<string, mixed> $normalized */
         $normalized = $reflection->invoke(null, $payload);

--- a/test/Services/CoreApi/ShipmentApiFactoryTest.php
+++ b/test/Services/CoreApi/ShipmentApiFactoryTest.php
@@ -10,23 +10,6 @@ use ReflectionMethod;
 
 final class ShipmentApiFactoryTest extends TestCase
 {
-    public function testNormalizeTrackTraceResponsePayloadNormalizesCarrierValues(): void
-    {
-        $payload = [
-            'data' => [
-                'tracktraces' => [
-                    ['carrier' => '1'],
-                    ['carrier' => 2],
-                ],
-            ],
-        ];
-
-        $normalized = $this->invokeFactoryNormalizer('normalizeTrackTraceResponsePayload', $payload);
-
-        self::assertSame(1, $normalized['data']['tracktraces'][0]['carrier']);
-        self::assertSame(2, $normalized['data']['tracktraces'][1]['carrier']);
-    }
-
     public function testNormalizeTrackTraceResponsePayloadKeepsStableFieldsOnly(): void
     {
         $payload = [

--- a/test/Services/Labels/ShipmentLabelsServiceTest.php
+++ b/test/Services/Labels/ShipmentLabelsServiceTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Services\Labels;
+
+use InvalidArgumentException;
+use Mockery;
+use MyParcelNL\Sdk\Exception\ApiException;
+use MyParcelNL\Sdk\Exception\MissingFieldException;
+use MyParcelNL\Sdk\Model\MyParcelRequest;
+use MyParcelNL\Sdk\Services\Labels\ShipmentLabelsService;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+final class ShipmentLabelsServiceTest extends TestCase
+{
+    public function testUseLabelPrepareThreshold(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        self::assertFalse($service->useLabelPrepare(MyParcelRequest::SHIPMENT_LABEL_PREPARE_ACTIVE_FROM));
+        self::assertTrue($service->useLabelPrepare(MyParcelRequest::SHIPMENT_LABEL_PREPARE_ACTIVE_FROM + 1));
+    }
+
+    public function testSetLinkOfLabelsUsesRegularEndpointAndStoresLink(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        $curlMock = $this->mockCurl();
+        $curlMock->shouldReceive('write')
+            ->once()
+            ->with(
+                'GET',
+                Mockery::on(static function ($url): bool {
+                    return is_string($url)
+                        && false !== strpos($url, '/shipment_labels/101;102/?format=A4&positions=2;3;4');
+                }),
+                Mockery::type('array'),
+                Mockery::any()
+            );
+
+        $curlMock->shouldReceive('getResponse')
+            ->once()
+            ->andReturn([
+                'response' => json_encode([
+                    'data' => [
+                        'pdfs' => [
+                            'url' => '/pdfs/download/101;102',
+                        ],
+                    ],
+                ]),
+                'code' => 200,
+            ]);
+
+        $curlMock->shouldReceive('close')->once();
+
+        $result = $service->setLinkOfLabels([101, 102], 2);
+
+        $expected = (new MyParcelRequest())->getRequestUrl() . '/pdfs/download/101;102';
+
+        self::assertSame($expected, $result);
+        self::assertSame($expected, $service->getLinkOfLabels());
+    }
+
+    public function testSetLinkOfLabelsUsesPreparedEndpointForLargeBatch(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        $ids = range(1, 26);
+
+        $curlMock = $this->mockCurl();
+        $curlMock->shouldReceive('write')
+            ->once()
+            ->with(
+                'GET',
+                Mockery::on(static function ($url): bool {
+                    return is_string($url)
+                        && false !== strpos($url, '/v2/shipment_labels/')
+                        && false !== strpos($url, '?format=A6');
+                }),
+                Mockery::type('array'),
+                Mockery::any()
+            );
+
+        $curlMock->shouldReceive('getResponse')
+            ->once()
+            ->andReturn([
+                'response' => json_encode([
+                    'data' => [
+                        'pdf' => [
+                            'url' => '/pdfs/prepared/abc',
+                        ],
+                    ],
+                ]),
+                'code' => 200,
+            ]);
+
+        $curlMock->shouldReceive('close')->once();
+
+        $result = $service->setLinkOfLabels($ids, false);
+
+        $expected = (new MyParcelRequest())->getRequestUrl() . '/pdfs/prepared/abc';
+
+        self::assertSame($expected, $result);
+        self::assertSame($expected, $service->getLinkOfLabels());
+    }
+
+    public function testSetLinkOfLabelsThrowsOnEmptyIds(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one shipment ID is required');
+
+        $service->setLinkOfLabels([]);
+    }
+
+    public function testSetPdfOfLabelsThrowsOnPaymentInstructions(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        $curlMock = $this->mockCurl();
+        $curlMock->shouldReceive('write')
+            ->once()
+            ->with(
+                'GET',
+                Mockery::on(static function ($url): bool {
+                    return is_string($url)
+                        && false !== strpos($url, '/shipment_labels/101/?format=A4&positions=1;2;3;4');
+                }),
+                Mockery::on(static function ($headers): bool {
+                    return is_array($headers)
+                        && isset($headers['Accept'])
+                        && 'application/pdf' === $headers['Accept'];
+                }),
+                Mockery::any()
+            );
+
+        $curlMock->shouldReceive('getResponse')
+            ->once()
+            ->andReturn([
+                'response' => json_encode([
+                    'data' => [
+                        'payment_instructions' => [
+                            'link' => 'https://pay.example.test',
+                        ],
+                    ],
+                ]),
+                'code' => 200,
+            ]);
+
+        $curlMock->shouldReceive('close')->once();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Received payment link instead of pdf. Check your MyParcel account status.');
+
+        $service->setPdfOfLabels([101]);
+    }
+
+    public function testSetPdfOfLabelsThrowsOnInvalidPdfResponse(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        $curlMock = $this->mockCurl();
+        $curlMock->shouldReceive('write')->once();
+        $curlMock->shouldReceive('getResponse')
+            ->once()
+            ->andReturn([
+                'response' => 'not-a-pdf',
+                'code' => 200,
+            ]);
+        $curlMock->shouldReceive('close')->once();
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Did not receive expected pdf response. Please contact MyParcel.');
+
+        $service->setPdfOfLabels([101]);
+    }
+
+    public function testDownloadPdfOfLabelsThrowsWhenPdfIsMissing(): void
+    {
+        $service = new ShipmentLabelsService($this->getApiKey());
+
+        $this->expectException(MissingFieldException::class);
+        $this->expectExceptionMessage('First set label_pdf key with setPdfOfLabels() before running downloadPdfOfLabels()');
+
+        $service->downloadPdfOfLabels();
+    }
+}

--- a/test/Services/Labels/ShipmentLabelsServiceTest.php
+++ b/test/Services/Labels/ShipmentLabelsServiceTest.php
@@ -6,7 +6,6 @@ namespace MyParcelNL\Sdk\Test\Services\Labels;
 
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
-use InvalidArgumentException;
 use Mockery;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
 use MyParcelNL\Sdk\Exception\ApiException;
@@ -119,18 +118,41 @@ final class ShipmentLabelsServiceTest extends TestCase
         self::assertSame($expected, $service->getLinkOfLabels());
     }
 
-    public function testSetLinkOfLabelsThrowsOnEmptyIds(): void
+    public function testSetLinkOfLabelsThrowsOnInvalidResponseBody(): void
     {
-        $service = new ShipmentLabelsService(
-            $this->getApiKey(),
-            Mockery::mock(ShipmentApi::class),
-            Mockery::mock(ClientInterface::class)
-        );
+        $api = Mockery::mock(ShipmentApi::class);
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $request = new Request('GET', 'https://api.myparcel.nl/shipment_labels/101?format=A4&positions=1;2;3;4');
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('At least one shipment ID is required');
+        $api->shouldReceive('getShipmentsLabelsRequest')
+            ->once()
+            ->with(
+                '101',
+                Mockery::type('string'),
+                'A4',
+                '1;2;3;4',
+                null,
+                null,
+                ShipmentApi::contentTypes['getShipmentsLabels'][0]
+            )
+            ->andReturn($request);
 
-        $service->setLinkOfLabels([]);
+        $httpClient->shouldReceive('sendRequest')
+            ->once()
+            ->with(Mockery::on(static function (RequestInterface $request): bool {
+                return ShipmentLabelsServiceTest::assertAcceptHeader(
+                    $request,
+                    'application/vnd.shipment_label_link+json'
+                );
+            }))
+            ->andReturn(new Response(200, [], 'not-json'));
+
+        $service = new ShipmentLabelsService($this->getApiKey(), $api, $httpClient);
+
+        $this->expectException(ApiException::class);
+        $this->expectExceptionMessage('Did not receive expected label link response. Please contact MyParcel.');
+
+        $service->setLinkOfLabels([101]);
     }
 
     public function testSetPdfOfLabelsThrowsOnPaymentInstructions(): void
@@ -155,7 +177,7 @@ final class ShipmentLabelsServiceTest extends TestCase
         $httpClient->shouldReceive('sendRequest')
             ->once()
             ->with(Mockery::on(static function (RequestInterface $request): bool {
-                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf+print');
             }))
             ->andReturn(new Response(200, [], json_encode([
                 'data' => [
@@ -195,7 +217,7 @@ final class ShipmentLabelsServiceTest extends TestCase
         $httpClient->shouldReceive('sendRequest')
             ->once()
             ->with(Mockery::on(static function (RequestInterface $request): bool {
-                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf+print');
             }))
             ->andReturn(new Response(200, [], 'not-a-pdf'));
 

--- a/test/Services/Labels/ShipmentLabelsServiceTest.php
+++ b/test/Services/Labels/ShipmentLabelsServiceTest.php
@@ -4,13 +4,18 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Sdk\Test\Services\Labels;
 
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use Mockery;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
 use MyParcelNL\Sdk\Exception\ApiException;
 use MyParcelNL\Sdk\Exception\MissingFieldException;
 use MyParcelNL\Sdk\Model\MyParcelRequest;
 use MyParcelNL\Sdk\Services\Labels\ShipmentLabelsService;
 use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 
 final class ShipmentLabelsServiceTest extends TestCase
 {
@@ -24,82 +29,91 @@ final class ShipmentLabelsServiceTest extends TestCase
 
     public function testSetLinkOfLabelsUsesRegularEndpointAndStoresLink(): void
     {
-        $service = new ShipmentLabelsService($this->getApiKey());
+        $api = Mockery::mock(ShipmentApi::class);
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $request = new Request('GET', 'https://api.myparcel.nl/shipment_labels/101;102?format=A4&positions=2;3;4');
 
-        $curlMock = $this->mockCurl();
-        $curlMock->shouldReceive('write')
+        $api->shouldReceive('getShipmentsLabelsRequest')
             ->once()
             ->with(
-                'GET',
-                Mockery::on(static function ($url): bool {
-                    return is_string($url)
-                        && false !== strpos($url, '/shipment_labels/101;102/?format=A4&positions=2;3;4');
-                }),
-                Mockery::type('array'),
-                Mockery::any()
-            );
+                '101;102',
+                Mockery::type('string'),
+                'A4',
+                '2;3;4',
+                null,
+                null,
+                ShipmentApi::contentTypes['getShipmentsLabels'][0]
+            )
+            ->andReturn($request);
 
-        $curlMock->shouldReceive('getResponse')
+        $httpClient->shouldReceive('sendRequest')
             ->once()
-            ->andReturn([
-                'response' => json_encode([
-                    'data' => [
-                        'pdfs' => [
-                            'url' => '/pdfs/download/101;102',
-                        ],
+            ->with(Mockery::on(static function (RequestInterface $request): bool {
+                return ShipmentLabelsServiceTest::assertAcceptHeader(
+                    $request,
+                    'application/vnd.shipment_label_link+json'
+                );
+            }))
+            ->andReturn(new Response(200, [], json_encode([
+                'data' => [
+                    'pdfs' => [
+                        'url' => '/pdfs/download/101;102',
                     ],
-                ]),
-                'code' => 200,
-            ]);
+                ],
+            ])));
 
-        $curlMock->shouldReceive('close')->once();
+        $service = new ShipmentLabelsService($this->getApiKey(), $api, $httpClient);
 
         $result = $service->setLinkOfLabels([101, 102], 2);
 
-        $expected = (new MyParcelRequest())->getRequestUrl() . '/pdfs/download/101;102';
+        $expected = 'https://api.myparcel.nl/pdfs/download/101;102';
 
         self::assertSame($expected, $result);
         self::assertSame($expected, $service->getLinkOfLabels());
     }
 
-    public function testSetLinkOfLabelsUsesPreparedEndpointForLargeBatch(): void
+    public function testSetLinkOfLabelsUsesGeneratedEndpointForLargeBatch(): void
     {
-        $service = new ShipmentLabelsService($this->getApiKey());
-
+        $api = Mockery::mock(ShipmentApi::class);
+        $httpClient = Mockery::mock(ClientInterface::class);
         $ids = range(1, 26);
+        $idsAsString = implode(';', $ids);
+        $request = new Request('GET', 'https://api.myparcel.nl/shipment_labels/' . $idsAsString . '?format=A6');
 
-        $curlMock = $this->mockCurl();
-        $curlMock->shouldReceive('write')
+        $api->shouldReceive('getShipmentsLabelsRequest')
             ->once()
             ->with(
-                'GET',
-                Mockery::on(static function ($url): bool {
-                    return is_string($url)
-                        && false !== strpos($url, '/v2/shipment_labels/')
-                        && false !== strpos($url, '?format=A6');
-                }),
-                Mockery::type('array'),
-                Mockery::any()
-            );
+                $idsAsString,
+                Mockery::type('string'),
+                'A6',
+                null,
+                null,
+                null,
+                ShipmentApi::contentTypes['getShipmentsLabels'][0]
+            )
+            ->andReturn($request);
 
-        $curlMock->shouldReceive('getResponse')
+        $httpClient->shouldReceive('sendRequest')
             ->once()
-            ->andReturn([
-                'response' => json_encode([
-                    'data' => [
-                        'pdf' => [
-                            'url' => '/pdfs/prepared/abc',
-                        ],
+            ->with(Mockery::on(static function (RequestInterface $request): bool {
+                return ShipmentLabelsServiceTest::assertAcceptHeader(
+                    $request,
+                    'application/vnd.shipment_label_link+json'
+                );
+            }))
+            ->andReturn(new Response(200, [], json_encode([
+                'data' => [
+                    'pdf' => [
+                        'url' => '/pdfs/prepared/abc',
                     ],
-                ]),
-                'code' => 200,
-            ]);
+                ],
+            ])));
 
-        $curlMock->shouldReceive('close')->once();
+        $service = new ShipmentLabelsService($this->getApiKey(), $api, $httpClient);
 
         $result = $service->setLinkOfLabels($ids, false);
 
-        $expected = (new MyParcelRequest())->getRequestUrl() . '/pdfs/prepared/abc';
+        $expected = 'https://api.myparcel.nl/pdfs/prepared/abc';
 
         self::assertSame($expected, $result);
         self::assertSame($expected, $service->getLinkOfLabels());
@@ -107,7 +121,11 @@ final class ShipmentLabelsServiceTest extends TestCase
 
     public function testSetLinkOfLabelsThrowsOnEmptyIds(): void
     {
-        $service = new ShipmentLabelsService($this->getApiKey());
+        $service = new ShipmentLabelsService(
+            $this->getApiKey(),
+            Mockery::mock(ShipmentApi::class),
+            Mockery::mock(ClientInterface::class)
+        );
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('At least one shipment ID is required');
@@ -117,39 +135,37 @@ final class ShipmentLabelsServiceTest extends TestCase
 
     public function testSetPdfOfLabelsThrowsOnPaymentInstructions(): void
     {
-        $service = new ShipmentLabelsService($this->getApiKey());
+        $api = Mockery::mock(ShipmentApi::class);
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $request = new Request('GET', 'https://api.myparcel.nl/shipment_labels/101?format=A4&positions=1;2;3;4');
 
-        $curlMock = $this->mockCurl();
-        $curlMock->shouldReceive('write')
+        $api->shouldReceive('getShipmentsLabelsRequest')
             ->once()
             ->with(
-                'GET',
-                Mockery::on(static function ($url): bool {
-                    return is_string($url)
-                        && false !== strpos($url, '/shipment_labels/101/?format=A4&positions=1;2;3;4');
-                }),
-                Mockery::on(static function ($headers): bool {
-                    return is_array($headers)
-                        && isset($headers['Accept'])
-                        && 'application/pdf' === $headers['Accept'];
-                }),
-                Mockery::any()
-            );
+                '101',
+                Mockery::type('string'),
+                'A4',
+                '1;2;3;4',
+                null,
+                null,
+                ShipmentApi::contentTypes['getShipmentsLabels'][0]
+            )
+            ->andReturn($request);
 
-        $curlMock->shouldReceive('getResponse')
+        $httpClient->shouldReceive('sendRequest')
             ->once()
-            ->andReturn([
-                'response' => json_encode([
-                    'data' => [
-                        'payment_instructions' => [
-                            'link' => 'https://pay.example.test',
-                        ],
+            ->with(Mockery::on(static function (RequestInterface $request): bool {
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
+            }))
+            ->andReturn(new Response(200, [], json_encode([
+                'data' => [
+                    'payment_instructions' => [
+                        'link' => 'https://pay.example.test',
                     ],
-                ]),
-                'code' => 200,
-            ]);
+                ],
+            ])));
 
-        $curlMock->shouldReceive('close')->once();
+        $service = new ShipmentLabelsService($this->getApiKey(), $api, $httpClient);
 
         $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Received payment link instead of pdf. Check your MyParcel account status.');
@@ -159,17 +175,31 @@ final class ShipmentLabelsServiceTest extends TestCase
 
     public function testSetPdfOfLabelsThrowsOnInvalidPdfResponse(): void
     {
-        $service = new ShipmentLabelsService($this->getApiKey());
+        $api = Mockery::mock(ShipmentApi::class);
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $request = new Request('GET', 'https://api.myparcel.nl/shipment_labels/101?format=A4&positions=1;2;3;4');
 
-        $curlMock = $this->mockCurl();
-        $curlMock->shouldReceive('write')->once();
-        $curlMock->shouldReceive('getResponse')
+        $api->shouldReceive('getShipmentsLabelsRequest')
             ->once()
-            ->andReturn([
-                'response' => 'not-a-pdf',
-                'code' => 200,
-            ]);
-        $curlMock->shouldReceive('close')->once();
+            ->with(
+                '101',
+                Mockery::type('string'),
+                'A4',
+                '1;2;3;4',
+                null,
+                null,
+                ShipmentApi::contentTypes['getShipmentsLabels'][0]
+            )
+            ->andReturn($request);
+
+        $httpClient->shouldReceive('sendRequest')
+            ->once()
+            ->with(Mockery::on(static function (RequestInterface $request): bool {
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
+            }))
+            ->andReturn(new Response(200, [], 'not-a-pdf'));
+
+        $service = new ShipmentLabelsService($this->getApiKey(), $api, $httpClient);
 
         $this->expectException(ApiException::class);
         $this->expectExceptionMessage('Did not receive expected pdf response. Please contact MyParcel.');
@@ -179,11 +209,20 @@ final class ShipmentLabelsServiceTest extends TestCase
 
     public function testDownloadPdfOfLabelsThrowsWhenPdfIsMissing(): void
     {
-        $service = new ShipmentLabelsService($this->getApiKey());
+        $service = new ShipmentLabelsService(
+            $this->getApiKey(),
+            Mockery::mock(ShipmentApi::class),
+            Mockery::mock(ClientInterface::class)
+        );
 
         $this->expectException(MissingFieldException::class);
         $this->expectExceptionMessage('First set label_pdf key with setPdfOfLabels() before running downloadPdfOfLabels()');
 
         $service->downloadPdfOfLabels();
+    }
+
+    private static function assertAcceptHeader(RequestInterface $request, string $expected): bool
+    {
+        return $expected === $request->getHeaderLine('Accept');
     }
 }

--- a/test/Services/ShipmentServicesLiveSmokeTest.php
+++ b/test/Services/ShipmentServicesLiveSmokeTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Services;
+
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
+use MyParcelNL\Sdk\Helper\ShipmentCollection;
+use MyParcelNL\Sdk\Model\MyParcelRequest;
+use MyParcelNL\Sdk\Model\Shipment\Carrier;
+use MyParcelNL\Sdk\Model\Shipment\PackageType;
+use MyParcelNL\Sdk\Model\Shipment\Shipment;
+use MyParcelNL\Sdk\Services\Labels\ShipmentLabelsService;
+use MyParcelNL\Sdk\Services\TrackTrace\ShipmentTrackTraceService;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+/**
+ * @group live
+ */
+final class ShipmentServicesLiveSmokeTest extends TestCase
+{
+    private string $liveApiKey;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $key = getenv('API_KEY') ?: getenv('API_KEY_NL') ?: getenv('API_KEY_BE');
+
+        if (! $key) {
+            $this->markTestSkipped('Skipping live smoke: no API key found (API_KEY / API_KEY_NL / API_KEY_BE).');
+        }
+
+        $this->liveApiKey = $key;
+
+        // Use real HTTP calls.
+        MyParcelRequest::setCurlFactory(null);
+    }
+
+    public function testSetLinkOfLabelsForCreatedShipment(): void
+    {
+        $collection = new ShipmentCollection($this->liveApiKey);
+        $collection->addShipment($this->createMinimalNlShipment('smoke-label-' . uniqid('', true)));
+
+        try {
+            $created = $collection->createConcepts();
+            $shipmentIds = array_keys($created);
+
+            $labels = new ShipmentLabelsService($this->liveApiKey);
+            $link = $labels->setLinkOfLabels($shipmentIds, false);
+        } catch (\Throwable $e) {
+            $this->handleLiveException($e);
+            return;
+        }
+
+        self::assertNotEmpty($link);
+        self::assertStringContainsString((new MyParcelRequest())->getRequestUrl(), $link);
+        self::assertSame($link, $labels->getLinkOfLabels());
+    }
+
+    public function testFetchTrackTraceDataForCreatedShipment(): void
+    {
+        $collection = new ShipmentCollection($this->liveApiKey);
+        $collection->addShipment($this->createMinimalNlShipment('smoke-tracktrace-' . uniqid('', true)));
+
+        try {
+            $created = $collection->createConcepts();
+            $shipmentIds = array_keys($created);
+
+            $trackTrace = new ShipmentTrackTraceService($this->liveApiKey);
+            $result = $trackTrace->fetchTrackTraceData($shipmentIds);
+        } catch (\Throwable $e) {
+            $this->handleLiveException($e);
+            return;
+        }
+
+        self::assertIsArray($result);
+
+        foreach ($shipmentIds as $shipmentId) {
+            if (! isset($result[$shipmentId])) {
+                continue;
+            }
+
+            self::assertSame($shipmentId, (int) $result[$shipmentId]['shipment_id']);
+        }
+    }
+
+    private function createMinimalNlShipment(string $referenceIdentifier): Shipment
+    {
+        return (new Shipment())
+            ->withCarrier(Carrier::POSTNL)
+            ->withPackageType(PackageType::PACKAGE)
+            ->withWeight(1000)
+            ->setRecipient([
+                'cc'          => 'NL',
+                'city'        => 'Hoofddorp',
+                'street'      => 'Antareslaan',
+                'number'      => '31',
+                'postal_code' => '2132JE',
+                'person'      => 'Smoke Test',
+                'email'       => 'smoke@myparcel.nl',
+                'phone'       => '0612345678',
+            ])
+            ->setReferenceIdentifier($referenceIdentifier);
+    }
+
+    private function handleLiveException(\Throwable $e): void
+    {
+        $message = $e->getMessage();
+
+        if (false !== strpos($message, 'Could not resolve host') ||
+            false !== strpos($message, 'cURL error 6') ||
+            false !== strpos($message, 'cURL error 7')) {
+            $this->markTestSkipped('Skipping live smoke: network unavailable: ' . $message);
+            return;
+        }
+
+        if ($e instanceof ConnectException) {
+            $this->markTestSkipped('Skipping live smoke: connection error: ' . $message);
+            return;
+        }
+
+        if ($e instanceof RequestException && $e->getResponse()) {
+            $code = $e->getResponse()->getStatusCode();
+            if ($code >= 500 || 429 === $code) {
+                $this->markTestSkipped(sprintf(
+                    'Skipping live smoke: transient API error HTTP %d: %s',
+                    $code,
+                    $message
+                ));
+                return;
+            }
+        }
+
+        throw $e;
+    }
+}

--- a/test/Services/ShipmentServicesLiveSmokeTest.php
+++ b/test/Services/ShipmentServicesLiveSmokeTest.php
@@ -6,10 +6,10 @@ namespace MyParcelNL\Sdk\Test\Services;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrierV2;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\MyParcelRequest;
-use MyParcelNL\Sdk\Model\Shipment\Carrier;
-use MyParcelNL\Sdk\Model\Shipment\PackageType;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\Labels\ShipmentLabelsService;
 use MyParcelNL\Sdk\Services\Shipment\ShipmentCreateService;
@@ -42,7 +42,7 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
     public function testSetLinkOfLabelsForCreatedShipment(): void
     {
         $collection = new ShipmentCollection();
-        $collection->add($this->createMinimalNlShipment('smoke-label-' . uniqid('', true)));
+        $collection->push($this->createMinimalNlShipment('smoke-label-' . uniqid('', true)));
 
         try {
             $createService = new ShipmentCreateService($this->liveApiKey);
@@ -64,7 +64,7 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
     public function testFetchTrackTraceDataForCreatedShipment(): void
     {
         $collection = new ShipmentCollection();
-        $collection->add($this->createMinimalNlShipment('smoke-tracktrace-' . uniqid('', true)));
+        $collection->push($this->createMinimalNlShipment('smoke-tracktrace-' . uniqid('', true)));
 
         try {
             $createService = new ShipmentCreateService($this->liveApiKey);
@@ -87,8 +87,8 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
     private function createMinimalNlShipment(string $referenceIdentifier): Shipment
     {
         return (new Shipment())
-            ->setCarrier(Carrier::POSTNL)
-            ->withPackageType(PackageType::PACKAGE)
+            ->setCarrier(RefTypesCarrierV2::POSTNL)
+            ->withPackageType(RefShipmentPackageTypeV2::PACKAGE)
             ->withWeight(1000)
             ->setRecipient([
                 'cc'          => 'NL',

--- a/test/Services/ShipmentServicesLiveSmokeTest.php
+++ b/test/Services/ShipmentServicesLiveSmokeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace MyParcelNL\Sdk\Test\Services;
 
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
@@ -11,6 +12,7 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrierV2;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\MyParcelRequest;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
+use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
 use MyParcelNL\Sdk\Services\Labels\ShipmentLabelsService;
 use MyParcelNL\Sdk\Services\Shipment\ShipmentCreateService;
 use MyParcelNL\Sdk\Services\TrackTrace\ShipmentTrackTraceService;
@@ -59,6 +61,40 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
         self::assertNotEmpty($link);
         self::assertStringContainsString((new MyParcelRequest())->getRequestUrl(), $link);
         self::assertSame($link, $labels->getLinkOfLabels());
+    }
+
+    public function testGeneratedLabelsRequestWithExplicitAcceptReturnsBody(): void
+    {
+        $collection = new ShipmentCollection();
+        $collection->push($this->createMinimalNlShipment('smoke-generated-label-body-' . uniqid('', true)));
+
+        try {
+            $createService = new ShipmentCreateService($this->liveApiKey);
+            $created = $createService->create($collection);
+            $shipmentIds = array_keys($created);
+
+            $api = ShipmentApiFactory::make($this->liveApiKey);
+            $request = $api->getShipmentsLabelsRequest(
+                implode(';', $shipmentIds),
+                'SDK-LiveSmoke/labels-body-check',
+                'A6'
+            )->withHeader('Accept', 'application/vnd.shipment_label_link+json');
+
+            $response = (new GuzzleClient(['timeout' => 10]))->send($request);
+            $body = (string) $response->getBody();
+        } catch (\Throwable $e) {
+            $this->handleLiveException($e);
+            return;
+        }
+
+        self::assertNotEmpty($body, 'Expected non-empty response body for label link request.');
+
+        $decoded = json_decode($body, true);
+        self::assertIsArray($decoded, 'Expected JSON body for label link response.');
+
+        $link = $decoded['data']['pdfs']['url'] ?? $decoded['data']['pdf']['url'] ?? null;
+        self::assertIsString($link, 'Expected label URL in response body.');
+        self::assertNotSame('', $link, 'Expected non-empty label URL in response body.');
     }
 
     public function testFetchTrackTraceDataForCreatedShipment(): void

--- a/test/Services/ShipmentServicesLiveSmokeTest.php
+++ b/test/Services/ShipmentServicesLiveSmokeTest.php
@@ -6,12 +6,13 @@ namespace MyParcelNL\Sdk\Test\Services;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
-use MyParcelNL\Sdk\Helper\ShipmentCollection;
+use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\MyParcelRequest;
 use MyParcelNL\Sdk\Model\Shipment\Carrier;
 use MyParcelNL\Sdk\Model\Shipment\PackageType;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\Labels\ShipmentLabelsService;
+use MyParcelNL\Sdk\Services\Shipment\ShipmentCreateService;
 use MyParcelNL\Sdk\Services\TrackTrace\ShipmentTrackTraceService;
 use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
 
@@ -40,11 +41,12 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
 
     public function testSetLinkOfLabelsForCreatedShipment(): void
     {
-        $collection = new ShipmentCollection($this->liveApiKey);
-        $collection->addShipment($this->createMinimalNlShipment('smoke-label-' . uniqid('', true)));
+        $collection = new ShipmentCollection();
+        $collection->add($this->createMinimalNlShipment('smoke-label-' . uniqid('', true)));
 
         try {
-            $created = $collection->createConcepts();
+            $createService = new ShipmentCreateService($this->liveApiKey);
+            $created = $createService->create($collection);
             $shipmentIds = array_keys($created);
 
             $labels = new ShipmentLabelsService($this->liveApiKey);
@@ -61,35 +63,31 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
 
     public function testFetchTrackTraceDataForCreatedShipment(): void
     {
-        $collection = new ShipmentCollection($this->liveApiKey);
-        $collection->addShipment($this->createMinimalNlShipment('smoke-tracktrace-' . uniqid('', true)));
+        $collection = new ShipmentCollection();
+        $collection->add($this->createMinimalNlShipment('smoke-tracktrace-' . uniqid('', true)));
 
         try {
-            $created = $collection->createConcepts();
+            $createService = new ShipmentCreateService($this->liveApiKey);
+            $created = $createService->create($collection);
             $shipmentIds = array_keys($created);
+            $shipmentId = (int) $shipmentIds[0];
 
             $trackTrace = new ShipmentTrackTraceService($this->liveApiKey);
-            $result = $trackTrace->fetchTrackTraceData($shipmentIds);
+            $result = $this->fetchTrackTraceWithRetry($trackTrace, $shipmentIds, $shipmentId);
         } catch (\Throwable $e) {
             $this->handleLiveException($e);
             return;
         }
 
         self::assertIsArray($result);
-
-        foreach ($shipmentIds as $shipmentId) {
-            if (! isset($result[$shipmentId])) {
-                continue;
-            }
-
-            self::assertSame($shipmentId, (int) $result[$shipmentId]['shipment_id']);
-        }
+        self::assertArrayHasKey($shipmentId, $result, 'Expected tracktrace for created shipment was not returned.');
+        self::assertSame($shipmentId, (int) $result[$shipmentId]->getShipmentId());
     }
 
     private function createMinimalNlShipment(string $referenceIdentifier): Shipment
     {
         return (new Shipment())
-            ->withCarrier(Carrier::POSTNL)
+            ->setCarrier(Carrier::POSTNL)
             ->withPackageType(PackageType::PACKAGE)
             ->withWeight(1000)
             ->setRecipient([
@@ -134,5 +132,35 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
         }
 
         throw $e;
+    }
+
+    /**
+     * Poll track & trace endpoint briefly to account for eventual consistency.
+     *
+     * @param int[] $shipmentIds
+     * @return array<int, mixed>
+     */
+    private function fetchTrackTraceWithRetry(
+        ShipmentTrackTraceService $trackTraceService,
+        array $shipmentIds,
+        int $expectedShipmentId,
+        int $attempts = 5,
+        int $sleepMilliseconds = 1000
+    ): array {
+        $lastResult = [];
+
+        for ($attempt = 1; $attempt <= $attempts; $attempt++) {
+            $lastResult = $trackTraceService->fetchTrackTraceData($shipmentIds);
+
+            if (isset($lastResult[$expectedShipmentId])) {
+                return $lastResult;
+            }
+
+            if ($attempt < $attempts) {
+                usleep($sleepMilliseconds * 1000);
+            }
+        }
+
+        return $lastResult;
     }
 }

--- a/test/Services/TrackTrace/ShipmentTrackTraceServiceTest.php
+++ b/test/Services/TrackTrace/ShipmentTrackTraceServiceTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Services\TrackTrace;
+
+use InvalidArgumentException;
+use Mockery;
+use MyParcelNL\Sdk\Services\TrackTrace\ShipmentTrackTraceService;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+final class ShipmentTrackTraceServiceTest extends TestCase
+{
+    public function testFetchTrackTraceDataThrowsOnEmptyIds(): void
+    {
+        $service = new ShipmentTrackTraceService($this->getApiKey());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('At least one shipment ID is required');
+
+        $service->fetchTrackTraceData([]);
+    }
+
+    public function testFetchTrackTraceDataRequestsCorrectUriAndMapsByShipmentId(): void
+    {
+        $service = new ShipmentTrackTraceService($this->getApiKey());
+        $service->setUserAgentForProposition('Magento', '2.4.7');
+
+        $curlMock = $this->mockCurl();
+
+        $curlMock->shouldReceive('write')
+            ->once()
+            ->with(
+                'GET',
+                Mockery::on(static function ($url): bool {
+                    return is_string($url)
+                        && false !== strpos($url, '/tracktraces/123;456');
+                }),
+                Mockery::on(static function ($headers): bool {
+                    return is_array($headers)
+                        && isset($headers['User-Agent'])
+                        && false !== strpos($headers['User-Agent'], 'Magento/2.4.7');
+                }),
+                Mockery::any()
+            );
+
+        $curlMock->shouldReceive('getResponse')
+            ->once()
+            ->andReturn([
+                'response' => json_encode([
+                    'data' => [
+                        'tracktraces' => [
+                            [
+                                'shipment_id' => 123,
+                                'link_tracktrace' => 'https://track.test/123',
+                                'history' => [['event' => 'created']],
+                            ],
+                            [
+                                'shipment_id' => 456,
+                                'link_tracktrace' => 'https://track.test/456',
+                                'history' => [['event' => 'created']],
+                            ],
+                        ],
+                    ],
+                ]),
+                'code' => 200,
+            ]);
+
+        $curlMock->shouldReceive('close')->once();
+
+        $result = $service->fetchTrackTraceData([123, 456]);
+
+        self::assertArrayHasKey(123, $result);
+        self::assertArrayHasKey(456, $result);
+        self::assertSame('https://track.test/123', $result[123]['link_tracktrace']);
+        self::assertSame('https://track.test/456', $result[456]['link_tracktrace']);
+    }
+}

--- a/test/Services/TrackTrace/ShipmentTrackTraceServiceTest.php
+++ b/test/Services/TrackTrace/ShipmentTrackTraceServiceTest.php
@@ -6,6 +6,10 @@ namespace MyParcelNL\Sdk\Test\Services\TrackTrace;
 
 use InvalidArgumentException;
 use Mockery;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsTrackTrace;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesTracktraces;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesTracktracesData;
 use MyParcelNL\Sdk\Services\TrackTrace\ShipmentTrackTraceService;
 use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
 
@@ -13,7 +17,7 @@ final class ShipmentTrackTraceServiceTest extends TestCase
 {
     public function testFetchTrackTraceDataThrowsOnEmptyIds(): void
     {
-        $service = new ShipmentTrackTraceService($this->getApiKey());
+        $service = new ShipmentTrackTraceService($this->getApiKey(), Mockery::mock(ShipmentApi::class));
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('At least one shipment ID is required');
@@ -21,58 +25,40 @@ final class ShipmentTrackTraceServiceTest extends TestCase
         $service->fetchTrackTraceData([]);
     }
 
-    public function testFetchTrackTraceDataRequestsCorrectUriAndMapsByShipmentId(): void
+    public function testFetchTrackTraceDataCallsGeneratedEndpointAndMapsByShipmentId(): void
     {
-        $service = new ShipmentTrackTraceService($this->getApiKey());
+        $api = Mockery::mock(ShipmentApi::class);
+        $service = new ShipmentTrackTraceService($this->getApiKey(), $api);
         $service->setUserAgentForProposition('Magento', '2.4.7');
 
-        $curlMock = $this->mockCurl();
+        $trackTrace1 = (new ShipmentDefsTrackTrace())
+            ->setShipmentId(123)
+            ->setLinkTracktrace('https://track.test/123');
+        $trackTrace2 = (new ShipmentDefsTrackTrace())
+            ->setShipmentId(456)
+            ->setLinkTracktrace('https://track.test/456');
 
-        $curlMock->shouldReceive('write')
+        $responseData = (new ShipmentResponsesTracktracesData())
+            ->setTracktraces([$trackTrace1, $trackTrace2]);
+        $response = (new ShipmentResponsesTracktraces())
+            ->setData($responseData);
+
+        $api->shouldReceive('getTrackTracesByIds')
             ->once()
             ->with(
-                'GET',
-                Mockery::on(static function ($url): bool {
-                    return is_string($url)
-                        && false !== strpos($url, '/tracktraces/123;456');
+                '123;456',
+                Mockery::on(static function ($userAgent): bool {
+                    return is_string($userAgent)
+                        && false !== strpos($userAgent, 'Magento/2.4.7');
                 }),
-                Mockery::on(static function ($headers): bool {
-                    return is_array($headers)
-                        && isset($headers['User-Agent'])
-                        && false !== strpos($headers['User-Agent'], 'Magento/2.4.7');
-                }),
-                Mockery::any()
-            );
-
-        $curlMock->shouldReceive('getResponse')
-            ->once()
-            ->andReturn([
-                'response' => json_encode([
-                    'data' => [
-                        'tracktraces' => [
-                            [
-                                'shipment_id' => 123,
-                                'link_tracktrace' => 'https://track.test/123',
-                                'history' => [['event' => 'created']],
-                            ],
-                            [
-                                'shipment_id' => 456,
-                                'link_tracktrace' => 'https://track.test/456',
-                                'history' => [['event' => 'created']],
-                            ],
-                        ],
-                    ],
-                ]),
-                'code' => 200,
-            ]);
-
-        $curlMock->shouldReceive('close')->once();
+            )
+            ->andReturn($response);
 
         $result = $service->fetchTrackTraceData([123, 456]);
 
         self::assertArrayHasKey(123, $result);
         self::assertArrayHasKey(456, $result);
-        self::assertSame('https://track.test/123', $result[123]['link_tracktrace']);
-        self::assertSame('https://track.test/456', $result[456]['link_tracktrace']);
+        self::assertSame('https://track.test/123', $result[123]->getLinkTracktrace());
+        self::assertSame('https://track.test/456', $result[456]->getLinkTracktrace());
     }
 }


### PR DESCRIPTION
Implements INT-1032 phase 3/4 by moving labels and track & trace flows from `MyParcelCollection` to shipment-first services.

### Changes
- Added `ShipmentLabelsService` (`src/Services/Labels/ShipmentLabelsService.php`)
- Added `ShipmentTrackTraceService` (`src/Services/TrackTrace/ShipmentTrackTraceService.php`) using generated `getTrackTracesByIds`
- Added/updated tests:
  - `test/Services/Labels/ShipmentLabelsServiceTest.php`
  - `test/Services/TrackTrace/ShipmentTrackTraceServiceTest.php`
  - `test/Services/CoreApi/ShipmentApiFactoryTest.php`
- Added live smoke coverage:
  - `test/Services/ShipmentServicesLiveSmokeTest.php`

### Notes
- Labels intentionally still use `MyParcelRequest` (generated labels flow is not sufficient yet for link/raw PDF + prepared flow).
- Track & trace uses the generated Shipments client endpoint.
- Track & trace response compatibility normalization remains centralized in `ShipmentApiFactory`.

### Test
- `ShipmentLabelsServiceTest`
- `ShipmentTrackTraceServiceTest`
- `ShipmentApiFactoryTest`
- `ShipmentServicesLiveSmokeTest`

INT-1032
