### PR TITLE
fix: fix monetary amounts not being serialized

### DIFF
--- a/openapi/coreapi.yaml
+++ b/openapi/coreapi.yaml
@@ -3,6 +3,9 @@
 # OpenAPI Generator configuration
 inputSpec: https://api.myparcel.nl/openapi.min.json
 outputDir: src/Client/Generated/CoreApi
+typeMappings:
+  # Map Empty model classes (oneOf) to primitives to avoid generating empty classes
+  RefTypesMoneyAmount: int
 # Maps inline schema names to shorter, cleaner class names
 inlineSchemaNameMappings:
   # Capabilities V2 - used in CapabilitiesMapper

--- a/src/Client/Generated/CoreApi/Model/RefTypesMoney.php
+++ b/src/Client/Generated/CoreApi/Model/RefTypesMoney.php
@@ -60,7 +60,7 @@ class RefTypesMoney implements ModelInterface, ArrayAccess, \JsonSerializable
       */
     protected static $openAPITypes = [
         'currency' => 'string',
-        'amount' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoneyAmount'
+        'amount' => 'int'
     ];
 
     /**
@@ -368,7 +368,7 @@ class RefTypesMoney implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Gets amount
      *
-     * @return \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoneyAmount
+     * @return int
      */
     public function getAmount()
     {
@@ -378,7 +378,7 @@ class RefTypesMoney implements ModelInterface, ArrayAccess, \JsonSerializable
     /**
      * Sets amount
      *
-     * @param \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoneyAmount $amount amount
+     * @param int $amount amount
      *
      * @return self
      */

--- a/src/Client/Generated/CoreApi/docs/Model/RefTypesMoney.md
+++ b/src/Client/Generated/CoreApi/docs/Model/RefTypesMoney.md
@@ -5,6 +5,6 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **currency** | **string** | The currency as uppercase 3-letter ISO 4217 code. |
-**amount** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoneyAmount**](RefTypesMoneyAmount.md) |  |
+**amount** | [**int**](RefTypesMoneyAmount.md) |  |
 
 [[Back to Model list]](../../README.md#models) [[Back to API list]](../../README.md#endpoints) [[Back to README]](../../README.md)


### PR DESCRIPTION
fixes monetary amounts not serializing due to complex `oneOf` constructions in the spec. maps it to int to workaround this issue with our generator.
