### PR TITLE
build: fix RefTypesMoneyAmount mapping not being applied anymore

### DIFF
--- a/openapi/coreapi.yaml
+++ b/openapi/coreapi.yaml
@@ -3,9 +3,6 @@
 # OpenAPI Generator configuration
 inputSpec: https://api.myparcel.nl/openapi.min.json
 outputDir: src/Client/Generated/CoreApi
-typeMappings:
-  # Map Empty model classes (oneOf) to primitives to avoid generating empty classes
-  RefTypesMoneyAmount: int
 # Maps inline schema names to shorter, cleaner class names
 inlineSchemaNameMappings:
   # Capabilities V2 - used in CapabilitiesMapper
@@ -22,6 +19,8 @@ inlineSchemaNameMappings:
   shipment_post_shipments_request_v1_1_data_shipments_inner: ShipmentRequest
   shipment_post_shipments_request_v1_1_data_shipments_inner_secondary_shipments_inner: SecondaryShipmentRequest
 typeMappings:
+  # Map Empty model classes (oneOf) to primitives to avoid generating empty classes
+  RefTypesMoneyAmount: int
   # @todo remove when upstream spec fixes street pattern + email enum
   # Redirects to override classes that fix broken setStreet() regex and setEmail() enum.
   ShipmentDefsShipmentRecipient: FixedShipmentRecipient


### PR DESCRIPTION
Fix the type mapping for monetary amounts not being applied on generated API clients

Doesn't fix the incorrect mapping, just the build config. Fix for the client to follow in regen-PR.
