### PR TITLE
fix: override iam principal deserialization via typeMappings

### DIFF
--- a/openapi/iam.yaml
+++ b/openapi/iam.yaml
@@ -3,6 +3,10 @@
 # OpenAPI Generator configuration
 inputSpec: https://iam.api.myparcel.nl/openapi.json
 outputDir: src/Client/Generated/IamApi
+typeMappings:
+  # @todo remove once upstream Principal generation is fixed
+  # Temporary override for correct whoami Principal deserialization.
+  Principal: FixedPrincipal
 additionalProperties:
   '!include': 'commonProperties.yaml'
   packageName: MyParcelNL\Sdk\Client\Generated\IamApi

--- a/src/Client/Generated/IamApi/Api/DefaultApi.php
+++ b/src/Client/Generated/IamApi/Api/DefaultApi.php
@@ -131,7 +131,7 @@ class DefaultApi
      *
      * @throws \MyParcelNL\Sdk\Client\Generated\IamApi\ApiException on non-2xx response or if the response body is not in the expected format
      * @throws \InvalidArgumentException
-     * @return \MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal
+     * @return \MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal
      */
     public function whoamiGet(string $contentType = self::contentTypes['whoamiGet'][0])
     {
@@ -148,7 +148,7 @@ class DefaultApi
      *
      * @throws \MyParcelNL\Sdk\Client\Generated\IamApi\ApiException on non-2xx response or if the response body is not in the expected format
      * @throws \InvalidArgumentException
-     * @return array of \MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal, HTTP status code, HTTP response headers (array of strings)
+     * @return array of \MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal, HTTP status code, HTTP response headers (array of strings)
      */
     public function whoamiGetWithHttpInfo(string $contentType = self::contentTypes['whoamiGet'][0])
     {
@@ -179,11 +179,11 @@ class DefaultApi
 
             switch($statusCode) {
                 case 200:
-                    if ('\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal' === '\SplFileObject') {
+                    if ('\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal' === '\SplFileObject') {
                         $content = $response->getBody(); //stream goes to serializer
                     } else {
                         $content = (string) $response->getBody();
-                        if ('\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal' !== 'string') {
+                        if ('\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal' !== 'string') {
                             try {
                                 $content = json_decode($content, false, 512, JSON_THROW_ON_ERROR);
                             } catch (\JsonException $exception) {
@@ -201,7 +201,7 @@ class DefaultApi
                     }
 
                     return [
-                        ObjectSerializer::deserialize($content, '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal', []),
+                        ObjectSerializer::deserialize($content, '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal', []),
                         $response->getStatusCode(),
                         $response->getHeaders()
                     ];
@@ -220,7 +220,7 @@ class DefaultApi
                 );
             }
 
-            $returnType = '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal';
+            $returnType = '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal';
             if ($returnType === '\SplFileObject') {
                 $content = $response->getBody(); //stream goes to serializer
             } else {
@@ -253,7 +253,7 @@ class DefaultApi
                 case 200:
                     $data = ObjectSerializer::deserialize(
                         $e->getResponseBody(),
-                        '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal',
+                        '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal',
                         $e->getResponseHeaders()
                     );
                     $e->setResponseObject($data);
@@ -295,7 +295,7 @@ class DefaultApi
      */
     public function whoamiGetAsyncWithHttpInfo(string $contentType = self::contentTypes['whoamiGet'][0])
     {
-        $returnType = '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal';
+        $returnType = '\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal';
         $request = $this->whoamiGetRequest($contentType);
 
         return $this->client

--- a/src/Client/Generated/IamApi/Model/FixedPrincipal.php
+++ b/src/Client/Generated/IamApi/Model/FixedPrincipal.php
@@ -1,0 +1,241 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Client\Generated\IamApi\Model;
+
+/**
+ * Temporary override for Principal.
+ *
+ * The IAM spec defines Principal as a discriminator-based union:
+ * - type=SHOP -> PrincipalShop -> role=RoleShop -> shopIds max 1
+ * - type=USER -> PrincipalUser -> role=RoleUser -> shopIds max 500
+ *
+ * The generated PHP parent incorrectly hardcodes `role` to RoleUser, which
+ * causes valid SHOP responses (for example SHOP_DEFAULT) to fail during
+ * deserialization.
+ *
+ * Registered via typeMappings in openapi/iam.yaml so that ObjectSerializer
+ * deserializes into this class instead of the broken generated parent.
+ *
+ * @todo remove once the upstream spec/codegen output for Principal is fixed
+ *       and the IAM client is regenerated.
+ */
+final class FixedPrincipal extends Principal
+{
+    /**
+     * Re-apply the discriminator-dependent fields through the override setters.
+     *
+     * The generated parent constructor writes raw values into the container and
+     * then overwrites `type` with the model name. Re-applying the input keeps
+     * manual construction aligned with deserialization behaviour.
+     *
+     * @param mixed[]|null $data
+     */
+    public function __construct(?array $data = null)
+    {
+        parent::__construct($data);
+
+        if (null === $data) {
+            return;
+        }
+
+        if (array_key_exists('type', $data)) {
+            $this->setType($data['type']);
+        }
+
+        if (array_key_exists('role', $data)) {
+            $this->setRole($data['role']);
+        }
+
+        if (array_key_exists('shop_ids', $data)) {
+            $this->setShopIds($data['shop_ids']);
+        }
+    }
+
+    /**
+     * Override the generated parent type map: on the shared Principal parent,
+     * `role` must remain a plain string until we know whether the principal is
+     * a SHOP or USER.
+     *
+     * @return array<string, string>
+     */
+    public static function openAPITypes()
+    {
+        $types = parent::openAPITypes();
+        $types['role'] = 'string';
+
+        return $types;
+    }
+
+    /**
+     * Gets role.
+     *
+     * @return string
+     */
+    public function getRole()
+    {
+        return $this->container['role'];
+    }
+
+    /**
+     * Sets role.
+     *
+     * @param string $role
+     *
+     * @return self
+     */
+    public function setRole($role)
+    {
+        if (is_null($role)) {
+            throw new \InvalidArgumentException('non-nullable role cannot be null');
+        }
+
+        $role = (string) $role;
+        $type = $this->container['type'] ?? null;
+
+        $this->assertRoleMatchesType($role, is_string($type) ? $type : null);
+
+        $this->container['role'] = $role;
+
+        return $this;
+    }
+
+    /**
+     * Sets type.
+     *
+     * Re-validates any existing role/shopIds against the selected branch.
+     *
+     * @param string $type
+     *
+     * @return self
+     */
+    public function setType($type)
+    {
+        parent::setType($type);
+
+        $role = $this->container['role'] ?? null;
+        if (is_string($role)) {
+            $this->assertRoleMatchesType($role, (string) $type);
+        }
+
+        $shopIds = $this->container['shop_ids'] ?? null;
+        if (is_array($shopIds)) {
+            $this->assertShopIdsMatchType($shopIds, (string) $type);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets shop_ids.
+     *
+     * @param string[] $shop_ids
+     *
+     * @return self
+     */
+    public function setShopIds($shop_ids)
+    {
+        if (is_null($shop_ids)) {
+            throw new \InvalidArgumentException('non-nullable shop_ids cannot be null');
+        }
+
+        if ((count($shop_ids) > 500)) {
+            throw new \InvalidArgumentException('invalid value for $shop_ids when calling Principal., number of items must be less than or equal to 500.');
+        }
+        if ((count($shop_ids) < 1)) {
+            throw new \InvalidArgumentException('invalid length for $shop_ids when calling Principal., number of items must be greater than or equal to 1.');
+        }
+
+        $type = $this->container['type'] ?? null;
+        $this->assertShopIdsMatchType($shop_ids, is_string($type) ? $type : null);
+
+        $this->container['shop_ids'] = $shop_ids;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * Adds the missing discriminator-dependent role/shopIds validation that the
+     * generated parent cannot express because it incorrectly treats role as
+     * RoleUser only and applies USER shopIds limits to both branches.
+     *
+     * @return string[]
+     */
+    public function listInvalidProperties()
+    {
+        $invalidProperties = parent::listInvalidProperties();
+
+        $type = $this->container['type'] ?? null;
+        $role = $this->container['role'] ?? null;
+        $shopIds = $this->container['shop_ids'] ?? null;
+
+        if (is_string($type) && is_string($role) && ! $this->isRoleAllowedForType($role, $type)) {
+            $invalidProperties[] = sprintf(
+                "invalid value '%s' for 'role' when type is '%s'",
+                $role,
+                $type
+            );
+        }
+
+        if (is_string($type) && is_array($shopIds) && self::TYPE_SHOP === $type && count($shopIds) > 1) {
+            $invalidProperties[] = "invalid value for 'shop_ids', number of items must be less than or equal to 1 when type is 'SHOP'.";
+        }
+
+        return array_values(array_unique($invalidProperties));
+    }
+
+    private function assertRoleMatchesType(string $role, ?string $type): void
+    {
+        if (null === $type) {
+            return;
+        }
+
+        if (! $this->isRoleAllowedForType($role, $type)) {
+            throw new \InvalidArgumentException(
+                sprintf(
+                    "Invalid value '%s' for 'role' when type is '%s'",
+                    $role,
+                    $type
+                )
+            );
+        }
+    }
+
+    private function assertShopIdsMatchType(array $shopIds, ?string $type): void
+    {
+        if (null === $type) {
+            return;
+        }
+
+        if (self::TYPE_SHOP === $type && count($shopIds) > 1) {
+            throw new \InvalidArgumentException(
+                "Invalid value for 'shop_ids' when type is 'SHOP', number of items must be less than or equal to 1."
+            );
+        }
+    }
+
+    private function isRoleAllowedForType(string $role, string $type): bool
+    {
+        return in_array($role, self::getAllowableRoleValuesForType($type), true);
+    }
+
+    /**
+     * @return string[]
+     */
+    private static function getAllowableRoleValuesForType(string $type): array
+    {
+        switch ($type) {
+            case self::TYPE_SHOP:
+                return RoleShop::getAllowableEnumValues();
+
+            case self::TYPE_USER:
+                return RoleUser::getAllowableEnumValues();
+
+            default:
+                return [];
+        }
+    }
+}

--- a/src/Client/Generated/IamApi/docs/Api/DefaultApi.md
+++ b/src/Client/Generated/IamApi/docs/Api/DefaultApi.md
@@ -10,7 +10,7 @@ All URIs are relative to https://iam.api.myparcel.nl, except if the operation de
 ## `whoamiGet()`
 
 ```php
-whoamiGet(): \MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal
+whoamiGet(): \MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal
 ```
 
 Find out who you are and what you can.
@@ -54,7 +54,7 @@ This endpoint does not need any parameter.
 
 ### Return type
 
-[**\MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal**](../Model/Principal.md)
+[**\MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal**](../Model/FixedPrincipal.md)
 
 ### Authorization
 

--- a/test/Client/Generated/IamApi/DefaultApiWhoamiTest.php
+++ b/test/Client/Generated/IamApi/DefaultApiWhoamiTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Client\Generated\IamApi;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use Psr\Http\Message\RequestInterface;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Api\DefaultApi;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Configuration;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+final class DefaultApiWhoamiTest extends TestCase
+{
+    public function testWhoamiGetDeserializesShopResponseAsFixedPrincipal(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('send')
+            ->with(
+                self::callback(function (RequestInterface $request): bool {
+                    self::assertSame('GET', $request->getMethod());
+                    self::assertSame('/whoami', $request->getUri()->getPath());
+                    self::assertSame('Bearer encoded_api_key', $request->getHeaderLine('Authorization'));
+
+                    return true;
+                }),
+                self::isType('array')
+            )
+            ->willReturn(new Response(200, [], json_encode([
+                'accountId' => '225196',
+                'platform' => 'MYPARCEL_NL',
+                'id' => '156402',
+                'role' => 'SHOP_DEFAULT',
+                'shopIds' => ['156402'],
+                'type' => 'SHOP',
+            ], JSON_THROW_ON_ERROR)));
+
+        $config = new Configuration();
+        $config->setHost('https://iam.api.myparcel.nl');
+        $config->setAccessToken('encoded_api_key');
+
+        $api = new DefaultApi($client, $config);
+        $principal = $api->whoamiGet();
+
+        self::assertInstanceOf(FixedPrincipal::class, $principal);
+        self::assertInstanceOf(Principal::class, $principal);
+        self::assertSame('SHOP', $principal->getType());
+        self::assertSame('SHOP_DEFAULT', $principal->getRole());
+        self::assertSame(['156402'], $principal->getShopIds());
+        self::assertTrue($principal->valid());
+    }
+
+    public function testWhoamiGetDeserializesUserResponseAsFixedPrincipal(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('send')
+            ->willReturn(new Response(200, [], json_encode([
+                'accountId' => '225196',
+                'platform' => 'MYPARCEL_NL',
+                'id' => '156403',
+                'role' => 'CUSTOMER_MAIN',
+                'shopIds' => ['156402', '156403'],
+                'type' => 'USER',
+            ], JSON_THROW_ON_ERROR)));
+
+        $config = new Configuration();
+        $config->setHost('https://iam.api.myparcel.nl');
+        $config->setAccessToken('encoded_api_key');
+
+        $api = new DefaultApi($client, $config);
+        $principal = $api->whoamiGet();
+
+        self::assertInstanceOf(FixedPrincipal::class, $principal);
+        self::assertSame('USER', $principal->getType());
+        self::assertSame('CUSTOMER_MAIN', $principal->getRole());
+        self::assertSame(['156402', '156403'], $principal->getShopIds());
+        self::assertTrue($principal->valid());
+    }
+}

--- a/test/Client/Generated/IamApi/FixedPrincipalTest.php
+++ b/test/Client/Generated/IamApi/FixedPrincipalTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Client\Generated\IamApi;
+
+use InvalidArgumentException;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Model\FixedPrincipal;
+use MyParcelNL\Sdk\Client\Generated\IamApi\Model\Principal;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+final class FixedPrincipalTest extends TestCase
+{
+    public function testShopPrincipalAcceptsShopRoleAndSingleShopId(): void
+    {
+        $principal = new FixedPrincipal([
+            'account_id' => '225196',
+            'platform' => 'MYPARCEL_NL',
+            'id' => '156402',
+            'role' => 'SHOP_DEFAULT',
+            'shop_ids' => ['156402'],
+            'type' => 'SHOP',
+        ]);
+
+        self::assertInstanceOf(FixedPrincipal::class, $principal);
+        self::assertInstanceOf(Principal::class, $principal);
+        self::assertSame('SHOP', $principal->getType());
+        self::assertSame('SHOP_DEFAULT', $principal->getRole());
+        self::assertSame(['156402'], $principal->getShopIds());
+        self::assertTrue($principal->valid());
+    }
+
+    public function testUserPrincipalAcceptsUserRoleAndMultipleShopIds(): void
+    {
+        $principal = new FixedPrincipal([
+            'account_id' => '225196',
+            'platform' => 'MYPARCEL_NL',
+            'id' => '156403',
+            'role' => 'CUSTOMER_MAIN',
+            'shop_ids' => ['156402', '156403'],
+            'type' => 'USER',
+        ]);
+
+        self::assertSame('USER', $principal->getType());
+        self::assertSame('CUSTOMER_MAIN', $principal->getRole());
+        self::assertSame(['156402', '156403'], $principal->getShopIds());
+        self::assertTrue($principal->valid());
+    }
+
+    public function testShopPrincipalRejectsUserRole(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid value 'CUSTOMER_MAIN' for 'role' when type is 'SHOP'");
+
+        new FixedPrincipal([
+            'account_id' => '225196',
+            'platform' => 'MYPARCEL_NL',
+            'id' => '156402',
+            'role' => 'CUSTOMER_MAIN',
+            'shop_ids' => ['156402'],
+            'type' => 'SHOP',
+        ]);
+    }
+
+    public function testShopPrincipalRejectsMultipleShopIds(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid value for 'shop_ids' when type is 'SHOP'");
+
+        new FixedPrincipal([
+            'account_id' => '225196',
+            'platform' => 'MYPARCEL_NL',
+            'id' => '156402',
+            'role' => 'SHOP_DEFAULT',
+            'shop_ids' => ['156402', '156403'],
+            'type' => 'SHOP',
+        ]);
+    }
+}


### PR DESCRIPTION
Fixes IAM `whoami` deserialization for shop principals by overriding the generated `Principal` parent model.

The generated IAM client currently hardcodes `Principal.role` to `RoleUser`, which causes valid shop responses to fail during deserialization. This PR applies a temporary override via `typeMappings`, similar to the existing fixes in the shipment domain.

This is a temporary workaround for `oneOf` handling in the PHP generator/client. The upstream spec/codegen issue should still be fixed so this override can be removed later.

INT-1494
