### PR TITLE
fix: harden v11 shipment service wrappers against spec/client drift

### DIFF
--- a/openapi/coreapi.yaml
+++ b/openapi/coreapi.yaml
@@ -31,6 +31,13 @@ typeMappings:
   # @todo remove when upstream spec fixes reference_identifier union type
   # The union ['null','integer','string'] generates an empty wrapper model that loses data.
   RefShipmentReferenceIdentifier: string
+  # @todo remove when upstream spec/codegen fixes region oneOf(string pattern | enum)
+  # The current codegen produces unusable model wrappers/enums for shipment resource regions.
+  ShipmentDefsShipmentRegion: string
+  ShipmentDefsShipmentPropertiesRegion: string
+  # @todo remove when upstream spec fixes return shipment payment_status empty-string responses
+  # Live return-shipment responses currently return "", which violates the enum and breaks deserialization.
+  ShipmentDefsShipmentPaymentStatus: string
 additionalProperties:
   '!include': 'commonProperties.yaml'
   packageName: MyParcelNL\Sdk\Client\Generated\CoreApi

--- a/src/Client/Generated/CoreApi/Model/SecondaryShipmentResource.php
+++ b/src/Client/Generated/CoreApi/Model/SecondaryShipmentResource.php
@@ -77,10 +77,10 @@ class SecondaryShipmentResource implements ModelInterface, ArrayAccess, \JsonSer
         'hidden' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesIntBoolean',
         'price' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoney',
         'barcode' => 'string',
-        'region' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPropertiesRegion',
+        'region' => 'string',
         'external_provider' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsExternalProviderPropertiesDisplayName',
         'external_provider_id' => 'int',
-        'payment_status' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus',
+        'payment_status' => 'string',
         'carrier_id' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrier',
         'platform_id' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\AccountDefsPlatformId',
         'origin' => 'string',
@@ -1278,7 +1278,7 @@ class SecondaryShipmentResource implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Gets region
      *
-     * @return \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPropertiesRegion
+     * @return string
      */
     public function getRegion()
     {
@@ -1288,7 +1288,7 @@ class SecondaryShipmentResource implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Sets region
      *
-     * @param \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPropertiesRegion $region region
+     * @param string $region region
      *
      * @return self
      */
@@ -1373,7 +1373,7 @@ class SecondaryShipmentResource implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Gets payment_status
      *
-     * @return \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus
+     * @return string
      */
     public function getPaymentStatus()
     {
@@ -1383,7 +1383,7 @@ class SecondaryShipmentResource implements ModelInterface, ArrayAccess, \JsonSer
     /**
      * Sets payment_status
      *
-     * @param \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus $payment_status payment_status
+     * @param string $payment_status payment_status
      *
      * @return self
      */

--- a/src/Client/Generated/CoreApi/Model/ShipmentDefsShipment.php
+++ b/src/Client/Generated/CoreApi/Model/ShipmentDefsShipment.php
@@ -77,10 +77,10 @@ class ShipmentDefsShipment implements ModelInterface, ArrayAccess, \JsonSerializ
         'hidden' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesIntBoolean',
         'price' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoney',
         'barcode' => 'string',
-        'region' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentRegion',
+        'region' => 'string',
         'external_provider' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentExternalProvider',
         'external_provider_id' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentExternalProviderId',
-        'payment_status' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus',
+        'payment_status' => 'string',
         'carrier_id' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrier',
         'platform_id' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\AccountDefsPlatformId',
         'origin' => '\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentOrigin',
@@ -1266,7 +1266,7 @@ class ShipmentDefsShipment implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Gets region
      *
-     * @return \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentRegion
+     * @return string
      */
     public function getRegion()
     {
@@ -1276,7 +1276,7 @@ class ShipmentDefsShipment implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Sets region
      *
-     * @param \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentRegion $region region
+     * @param string $region region
      *
      * @return self
      */
@@ -1347,7 +1347,7 @@ class ShipmentDefsShipment implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Gets payment_status
      *
-     * @return \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus
+     * @return string
      */
     public function getPaymentStatus()
     {
@@ -1357,7 +1357,7 @@ class ShipmentDefsShipment implements ModelInterface, ArrayAccess, \JsonSerializ
     /**
      * Sets payment_status
      *
-     * @param \MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus $payment_status payment_status
+     * @param string $payment_status payment_status
      *
      * @return self
      */

--- a/src/Client/Generated/CoreApi/docs/Model/SecondaryShipmentResource.md
+++ b/src/Client/Generated/CoreApi/docs/Model/SecondaryShipmentResource.md
@@ -23,10 +23,10 @@ Name | Type | Description | Notes
 **hidden** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesIntBoolean**](RefTypesIntBoolean.md) |  |
 **price** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoney**](RefTypesMoney.md) |  |
 **barcode** | **string** |  |
-**region** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPropertiesRegion**](ShipmentDefsShipmentPropertiesRegion.md) |  |
+**region** | [**string**](ShipmentDefsShipmentPropertiesRegion.md) |  |
 **external_provider** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsExternalProviderPropertiesDisplayName**](ShipmentDefsExternalProviderPropertiesDisplayName.md) |  |
 **external_provider_id** | **int** |  |
-**payment_status** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus**](ShipmentDefsShipmentPaymentStatus.md) |  |
+**payment_status** | [**string**](ShipmentDefsShipmentPaymentStatus.md) |  |
 **carrier_id** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrier**](RefTypesCarrier.md) |  |
 **platform_id** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\AccountDefsPlatformId**](AccountDefsPlatformId.md) |  |
 **origin** | **string** |  |

--- a/src/Client/Generated/CoreApi/docs/Model/ShipmentDefsShipment.md
+++ b/src/Client/Generated/CoreApi/docs/Model/ShipmentDefsShipment.md
@@ -23,10 +23,10 @@ Name | Type | Description | Notes
 **hidden** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesIntBoolean**](RefTypesIntBoolean.md) |  |
 **price** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesMoney**](RefTypesMoney.md) |  |
 **barcode** | **string** |  |
-**region** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentRegion**](ShipmentDefsShipmentRegion.md) |  |
+**region** | [**string**](ShipmentDefsShipmentRegion.md) |  |
 **external_provider** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentExternalProvider**](ShipmentDefsShipmentExternalProvider.md) |  |
 **external_provider_id** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentExternalProviderId**](ShipmentDefsShipmentExternalProviderId.md) |  |
-**payment_status** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentPaymentStatus**](ShipmentDefsShipmentPaymentStatus.md) |  |
+**payment_status** | [**string**](ShipmentDefsShipmentPaymentStatus.md) |  |
 **carrier_id** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrier**](RefTypesCarrier.md) |  |
 **platform_id** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\AccountDefsPlatformId**](AccountDefsPlatformId.md) |  |
 **origin** | [**\MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipmentOrigin**](ShipmentDefsShipmentOrigin.md) |  |

--- a/src/Services/CoreApi/Concerns/ResolvesPostShipmentsContentType.php
+++ b/src/Services/CoreApi/Concerns/ResolvesPostShipmentsContentType.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Services\CoreApi\Concerns;
+
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use RuntimeException;
+
+trait ResolvesPostShipmentsContentType
+{
+    /**
+     * Resolve a postShipments content type by prefix instead of array index.
+     *
+     * This keeps the generated ShipmentApi client as source of truth while avoiding
+     * fragile coupling to the order of ShipmentApi::contentTypes['postShipments'].
+     */
+    private function resolvePostShipmentsContentType(string $prefix): string
+    {
+        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
+            if (0 === strpos($contentType, $prefix)) {
+                return $contentType;
+            }
+        }
+
+        throw new RuntimeException(sprintf(
+            'No matching content type starting with "%s" configured in generated ShipmentApi client.',
+            $prefix
+        ));
+    }
+}

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -19,7 +19,6 @@ use Psr\Http\Message\RequestInterface;
  *
  * @todo Temporary workaround: use generated request-builder + manual sendRequest()
  *       because generated ShipmentApi::getShipmentsLabels() currently exposes a void return flow.
- *       Replace with direct generated response handling once spec/generator returns typed label body.
  */
 final class ShipmentLabelsService
 {
@@ -27,7 +26,7 @@ final class ShipmentLabelsService
 
     private const PREFIX_PDF_FILENAME = 'myparcel-label-';
     private const LABEL_LINK_ACCEPT_HEADER = 'application/vnd.shipment_label_link+json';
-    private const PDF_ACCEPT_HEADER = 'application/pdf+print';
+    private const PDF_ACCEPT_HEADER = 'application/pdf';
     private const SHIPMENT_LABEL_PREPARE_ACTIVE_FROM = 25;
 
     private ShipmentApi $api;

--- a/src/Services/Labels/ShipmentLabelsService.php
+++ b/src/Services/Labels/ShipmentLabelsService.php
@@ -17,8 +17,11 @@ use Psr\Http\Message\RequestInterface;
 /**
  * Service for retrieving shipment labels (link/PDF) by shipment IDs.
  *
+ * This service intentionally keeps the legacy link/PDF behavior intact.
+ *
  * @todo Temporary workaround: use generated request-builder + manual sendRequest()
- *       because generated ShipmentApi::getShipmentsLabels() currently exposes a void return flow.
+ *       because generated ShipmentApi::getShipmentsLabels() currently exposes a void return flow,
+ *       while this SDK still needs the existing link/PDF response handling.
  */
 final class ShipmentLabelsService
 {
@@ -48,6 +51,9 @@ final class ShipmentLabelsService
 
     /**
      * Fetch and store the label download link for the given shipments.
+     *
+     * Hybrid note: request construction comes from the generated client, but response parsing
+     * stays local for now because the generated labels operation does not expose a typed return model.
      *
      * @param int[] $shipmentIds
      * @param mixed $positions Label positions (numeric for A4, array for explicit slots, other for A6).
@@ -86,6 +92,9 @@ final class ShipmentLabelsService
 
     /**
      * Fetch and store the raw PDF content for the given shipment labels.
+     *
+     * Hybrid note: this keeps the existing PDF flow intact and only overrides Accept to request
+     * the old PDF variant directly.
      *
      * @param int[] $shipmentIds
      * @param mixed $positions Label positions (numeric for A4, array for explicit slots, other for A6).
@@ -156,6 +165,9 @@ final class ShipmentLabelsService
 
     /**
      * Build label request using generated ShipmentApi request builder.
+     *
+     * The generated builder stays the source of truth for the request contract; this service only
+     * applies Accept negotiation on top for the legacy link/PDF flows.
      *
      * @param int[] $shipmentIds
      */

--- a/src/Services/Returns/ReturnShipmentService.php
+++ b/src/Services/Returns/ReturnShipmentService.php
@@ -7,12 +7,15 @@ namespace MyParcelNL\Sdk\Services\Returns;
 use GuzzleHttp\Client as GuzzleClient;
 use InvalidArgumentException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipment;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostReturnShipmentsRequest;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostReturnShipmentsRequestData;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostReturnShipmentsRequestDataReturnShipmentsInner;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostUnrelatedReturnShipmentsRequest;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostUnrelatedReturnShipmentsRequestData;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostUnrelatedReturnShipmentsRequestDataReturnShipmentsInner;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesPostShipmentsV12;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\ObjectSerializer;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
 use Psr\Http\Client\ClientInterface as PsrClientInterface;
@@ -73,7 +76,7 @@ final class ReturnShipmentService
             null,
             null,
             null,
-            ShipmentApi::contentTypes['postShipments'][2]
+            $this->resolveContentType('application/vnd.return_shipment+json')
         );
 
         $request = $this->withQueryParameter($request, 'send_return_mail', $sendMail ? '1' : '0');
@@ -110,7 +113,7 @@ final class ReturnShipmentService
             null,
             null,
             null,
-            ShipmentApi::contentTypes['postShipments'][3]
+            $this->resolveContentType('application/vnd.unrelated_return_shipment+json')
         );
 
         return $this->sendAndParseIdsResponse($request);
@@ -124,20 +127,45 @@ final class ReturnShipmentService
         $response = $this->httpClient->sendRequest($request);
 
         $body = (string) $response->getBody();
-        $decoded = json_decode($body, true);
-        $ids = is_array($decoded) && isset($decoded['data']['ids']) && is_array($decoded['data']['ids'])
-            ? $decoded['data']['ids']
-            : [];
+        if ('' === $body) {
+            return [];
+        }
 
+        try {
+            $decoded = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            return [];
+        }
+
+        $responseModel = ObjectSerializer::deserialize(
+            $decoded,
+            ShipmentResponsesPostShipmentsV12::class,
+            []
+        );
+
+        if (! $responseModel instanceof ShipmentResponsesPostShipmentsV12 || null === $responseModel->getData()) {
+            return [];
+        }
+
+        return $this->mapCreatedShipments($responseModel->getData()->getShipments() ?? []);
+    }
+
+    /**
+     * @param ShipmentDefsShipment[] $shipments
+     *
+     * @return array<int, string|null>
+     */
+    private function mapCreatedShipments(array $shipments): array
+    {
         $mapping = [];
-        foreach ($ids as $item) {
-            if (! is_array($item) || ! isset($item['id'])) {
+
+        foreach ($shipments as $shipment) {
+            $shipmentId = $shipment->getId();
+            if (null === $shipmentId) {
                 continue;
             }
 
-            $mapping[(int) $item['id']] = isset($item['reference_identifier'])
-                ? (string) $item['reference_identifier']
-                : null;
+            $mapping[(int) $shipmentId] = $shipment->getReferenceIdentifier();
         }
 
         return $mapping;
@@ -152,6 +180,20 @@ final class ReturnShipmentService
         $query[$key] = $value;
 
         return $request->withUri($uri->withQuery(http_build_query($query)));
+    }
+
+    private function resolveContentType(string $prefix): string
+    {
+        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
+            if (0 === strpos($contentType, $prefix)) {
+                return $contentType;
+            }
+        }
+
+        throw new \RuntimeException(sprintf(
+            'No matching content type starting with "%s" configured in generated ShipmentApi client.',
+            $prefix
+        ));
     }
 
 }

--- a/src/Services/Returns/ReturnShipmentService.php
+++ b/src/Services/Returns/ReturnShipmentService.php
@@ -18,6 +18,7 @@ use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesPostShipments
 use MyParcelNL\Sdk\Client\Generated\CoreApi\ObjectSerializer;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
+use MyParcelNL\Sdk\Services\CoreApi\Concerns\ResolvesPostShipmentsContentType;
 use Psr\Http\Client\ClientInterface as PsrClientInterface;
 use Psr\Http\Message\RequestInterface;
 
@@ -38,6 +39,7 @@ use Psr\Http\Message\RequestInterface;
 final class ReturnShipmentService
 {
     use HasUserAgent;
+    use ResolvesPostShipmentsContentType;
 
     private ShipmentApi $api;
 
@@ -85,7 +87,7 @@ final class ReturnShipmentService
             null,
             null,
             null,
-            $this->resolveContentType('application/vnd.return_shipment+json')
+            $this->resolvePostShipmentsContentType('application/vnd.return_shipment+json')
         );
 
         $request = $this->withQueryParameter($request, 'send_return_mail', $sendMail ? '1' : '0');
@@ -125,7 +127,7 @@ final class ReturnShipmentService
             null,
             null,
             null,
-            $this->resolveContentType('application/vnd.unrelated_return_shipment+json')
+            $this->resolvePostShipmentsContentType('application/vnd.unrelated_return_shipment+json')
         );
 
         return $this->sendAndParseIdsResponse($request);
@@ -187,26 +189,6 @@ final class ReturnShipmentService
         $query[$key] = $value;
 
         return $request->withUri($uri->withQuery(http_build_query($query)));
-    }
-
-    /**
-     * Resolve the generated return shipment content type by prefix instead of array index.
-     *
-     * This keeps the generated client as source of truth while avoiding fragile coupling to
-     * the internal order of ShipmentApi::contentTypes['postShipments'].
-     */
-    private function resolveContentType(string $prefix): string
-    {
-        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
-            if (0 === strpos($contentType, $prefix)) {
-                return $contentType;
-            }
-        }
-
-        throw new \RuntimeException(sprintf(
-            'No matching content type starting with "%s" configured in generated ShipmentApi client.',
-            $prefix
-        ));
     }
 
 }

--- a/src/Services/Returns/ReturnShipmentService.php
+++ b/src/Services/Returns/ReturnShipmentService.php
@@ -24,7 +24,13 @@ use Psr\Http\Message\RequestInterface;
 /**
  * Return shipment creation service.
  *
- * Uses generated request models and request builder as source of truth.
+ * Uses generated request models and response models as source of truth.
+ *
+ * This service remains hybrid because the generated operation methods do not yet expose
+ * the related return variants we need here, such as send_return_mail and unrelated returns.
+ * Until those parameters are modeled directly on the generated operation signatures, we build
+ * the request with the generated request builder and deserialize the response with the generated
+ * response model ourselves.
  *
  * @todo switch to direct generated methods once send_return_mail and unrelated return contracts
  *       are fully represented by the generated operation signatures.
@@ -49,6 +55,9 @@ final class ReturnShipmentService
 
     /**
      * Create return shipments linked to existing parent shipment ids.
+     *
+     * Hybrid note: we still use postShipmentsRequest() here so we can append the
+     * send_return_mail query parameter without hardcoding the rest of the request contract.
      *
      * @param array<int, array<string, mixed>> $returnShipments
      * @return array<int, string|null>
@@ -87,6 +96,9 @@ final class ReturnShipmentService
     /**
      * Create unrelated return shipments.
      *
+     * Hybrid note: unrelated returns currently reuse the generated request builder because
+     * this variant is not yet exposed as a dedicated generated operation method.
+     *
      * @param array<int, array<string, mixed>> $returnShipments
      * @return array<int, string|null>
      */
@@ -120,22 +132,17 @@ final class ReturnShipmentService
     }
 
     /**
+     * Send the prepared hybrid request and deserialize it with the generated success model.
+     *
+     * We intentionally do not swallow parse or contract errors here; hybrid transport should
+     * still fail loudly when the generated client contract no longer matches the live response.
+     *
      * @return array<int, string|null>
      */
     private function sendAndParseIdsResponse(RequestInterface $request): array
     {
         $response = $this->httpClient->sendRequest($request);
-
-        $body = (string) $response->getBody();
-        if ('' === $body) {
-            return [];
-        }
-
-        try {
-            $decoded = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            return [];
-        }
+        $decoded = json_decode((string) $response->getBody(), false, 512, JSON_THROW_ON_ERROR);
 
         $responseModel = ObjectSerializer::deserialize(
             $decoded,
@@ -144,7 +151,7 @@ final class ReturnShipmentService
         );
 
         if (! $responseModel instanceof ShipmentResponsesPostShipmentsV12 || null === $responseModel->getData()) {
-            return [];
+            throw new InvalidArgumentException('Unexpected response type returned while parsing return shipment response.');
         }
 
         return $this->mapCreatedShipments($responseModel->getData()->getShipments() ?? []);
@@ -182,6 +189,12 @@ final class ReturnShipmentService
         return $request->withUri($uri->withQuery(http_build_query($query)));
     }
 
+    /**
+     * Resolve the generated return shipment content type by prefix instead of array index.
+     *
+     * This keeps the generated client as source of truth while avoiding fragile coupling to
+     * the internal order of ShipmentApi::contentTypes['postShipments'].
+     */
     private function resolveContentType(string $prefix): string
     {
         foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {

--- a/src/Services/Shipment/ShipmentCreateService.php
+++ b/src/Services/Shipment/ShipmentCreateService.php
@@ -119,20 +119,29 @@ final class ShipmentCreateService
         }
 
         $responseData = $response->getData();
+        if (null === $responseData) {
+            throw new InvalidArgumentException('ShipmentApi::postShipments() returned a response without data.');
+        }
+
         $requestReferences = array_values(array_map(
             static fn (Shipment $shipment): ?string => $shipment->getReferenceIdentifier(),
             $shipments
         ));
 
         $mapping = [];
-        foreach ($responseData->getShipments() as $index => $createdShipment) {
+        foreach (($responseData->getShipments() ?? []) as $index => $createdShipment) {
             $referenceIdentifier = $createdShipment->getReferenceIdentifier();
 
             if (null === $referenceIdentifier && isset($requestReferences[$index])) {
                 $referenceIdentifier = $requestReferences[$index];
             }
 
-            $mapping[(int) $createdShipment->getId()] = $referenceIdentifier;
+            $shipmentId = $createdShipment->getId();
+            if (null === $shipmentId) {
+                continue;
+            }
+
+            $mapping[(int) $shipmentId] = $referenceIdentifier;
         }
 
         return $mapping;

--- a/src/Services/Shipment/ShipmentCreateService.php
+++ b/src/Services/Shipment/ShipmentCreateService.php
@@ -33,6 +33,10 @@ final class ShipmentCreateService
     /**
      * Create shipments through the generated ShipmentApi client.
      *
+     * Builds the generated request model, applies SDK defaults such as reference identifiers,
+     * and maps the typed generated success response back to the SDK's
+     * id => reference_identifier return shape.
+     *
      * @param ShipmentCollection $collection Collection of shipments to create.
      * @param mixed              $format     Label format (e.g. "A4", "A6") or generated format reference.
      * @param mixed              $positions  Label position(s) for A4 (e.g. "1;2;3;4") or generated position reference.
@@ -62,6 +66,9 @@ final class ShipmentCreateService
         return $this->parseCreateResponse($shipments, $response);
     }
 
+    /**
+     * Resolve the generated shipment create content type by prefix instead of array index.
+     */
     private function resolveShipmentCreateContentType(): string
     {
         foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
@@ -100,6 +107,8 @@ final class ShipmentCreateService
 
     /**
      * @param Shipment[] $shipments
+     *
+     * Read only the current generated success model and translate it to the SDK convenience shape.
      *
      * @return array<int, string|null>
      */

--- a/src/Services/Shipment/ShipmentCreateService.php
+++ b/src/Services/Shipment/ShipmentCreateService.php
@@ -13,12 +13,14 @@ use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
+use MyParcelNL\Sdk\Services\CoreApi\Concerns\ResolvesPostShipmentsContentType;
 use MyParcelNL\Sdk\Services\Shipment\Concerns\EnsuresShipmentReferenceIds;
 
 final class ShipmentCreateService
 {
     use HasUserAgent;
     use EnsuresShipmentReferenceIds;
+    use ResolvesPostShipmentsContentType;
 
     private ShipmentApi $api;
 
@@ -60,24 +62,10 @@ final class ShipmentCreateService
             $positions,
             null,
             null,
-            $this->resolveShipmentCreateContentType()
+            $this->resolvePostShipmentsContentType('application/vnd.shipment+json')
         );
 
         return $this->parseCreateResponse($shipments, $response);
-    }
-
-    /**
-     * Resolve the generated shipment create content type by prefix instead of array index.
-     */
-    private function resolveShipmentCreateContentType(): string
-    {
-        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
-            if (0 === strpos($contentType, 'application/vnd.shipment+json')) {
-                return $contentType;
-            }
-        }
-
-        throw new \RuntimeException('No shipment create content type configured in generated ShipmentApi client.');
     }
 
     /**

--- a/src/Services/Shipment/ShipmentCreateService.php
+++ b/src/Services/Shipment/ShipmentCreateService.php
@@ -6,9 +6,9 @@ namespace MyParcelNL\Sdk\Services\Shipment;
 
 use InvalidArgumentException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\InlineObject;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11Data;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesPostShipmentsV12;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
@@ -56,10 +56,21 @@ final class ShipmentCreateService
             $positions,
             null,
             null,
-            ShipmentApi::contentTypes['postShipments'][0]
+            $this->resolveShipmentCreateContentType()
         );
 
         return $this->parseCreateResponse($shipments, $response);
+    }
+
+    private function resolveShipmentCreateContentType(): string
+    {
+        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
+            if (0 === strpos($contentType, 'application/vnd.shipment+json')) {
+                return $contentType;
+            }
+        }
+
+        throw new \RuntimeException('No shipment create content type configured in generated ShipmentApi client.');
     }
 
     /**
@@ -94,7 +105,7 @@ final class ShipmentCreateService
      */
     private function parseCreateResponse(array $shipments, $response): array
     {
-        if (! $response instanceof InlineObject) {
+        if (! $response instanceof ShipmentResponsesPostShipmentsV12) {
             throw new InvalidArgumentException('Unexpected response type returned by ShipmentApi::postShipments()');
         }
 
@@ -105,56 +116,16 @@ final class ShipmentCreateService
         ));
 
         $mapping = [];
-        foreach ($responseData->getIds() as $index => $idObject) {
-            $referenceIdentifier = $this->normalizeReferenceIdentifier($idObject->getReferenceIdentifier());
+        foreach ($responseData->getShipments() as $index => $createdShipment) {
+            $referenceIdentifier = $createdShipment->getReferenceIdentifier();
 
-            // @todo remove after CoreAPI spec/codegen fix:
-            // Generated client may deserialize reference_identifier as wrapper object.
             if (null === $referenceIdentifier && isset($requestReferences[$index])) {
                 $referenceIdentifier = $requestReferences[$index];
             }
 
-            $mapping[(int) $idObject->getId()] = $referenceIdentifier;
+            $mapping[(int) $createdShipment->getId()] = $referenceIdentifier;
         }
 
         return $mapping;
-    }
-
-    /**
-     * @todo remove after CoreAPI spec/codegen fix:
-     * Normalize generated reference_identifier values to scalar strings.
-     */
-    private function normalizeReferenceIdentifier($referenceIdentifier): ?string
-    {
-        if (null === $referenceIdentifier) {
-            return null;
-        }
-
-        if (is_string($referenceIdentifier) || is_int($referenceIdentifier) || is_float($referenceIdentifier)) {
-            return (string) $referenceIdentifier;
-        }
-
-        if (! is_object($referenceIdentifier)) {
-            return null;
-        }
-
-        if (method_exists($referenceIdentifier, '__toString')) {
-            try {
-                $asString = (string) $referenceIdentifier;
-                if ('' !== $asString && '{}' !== $asString) {
-                    return $asString;
-                }
-            } catch (\Throwable $e) {
-                // ignore and continue
-            }
-        }
-
-        $decoded = json_decode(json_encode($referenceIdentifier), true);
-
-        if (is_string($decoded) || is_int($decoded) || is_float($decoded)) {
-            return (string) $decoded;
-        }
-
-        return null;
     }
 }

--- a/src/Services/Shipment/ShipmentPrintService.php
+++ b/src/Services/Shipment/ShipmentPrintService.php
@@ -9,12 +9,16 @@ use InvalidArgumentException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11Data;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesShipmentIds;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesShipmentIdsDataIdsInner;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\ObjectSerializer;
 use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
 use MyParcelNL\Sdk\Services\Shipment\Concerns\EnsuresShipmentReferenceIds;
 use Psr\Http\Client\ClientInterface as PsrClientInterface;
+use Psr\Http\Message\RequestInterface;
 
 /**
  * Direct print flow for shipments.
@@ -59,21 +63,35 @@ final class ShipmentPrintService
         $this->ensureReferenceIds($shipments);
 
         $requestModel = $this->buildCreateRequest($shipments);
+        $request = $this->createDirectPrintRequest($requestModel, $printerGroupId);
 
-        $request = $this->api->postShipmentsRequest(
+        return $this->sendAndParseIdsResponse($request);
+    }
+
+    private function createDirectPrintRequest(
+        ShipmentPostShipmentsRequestV11 $requestModel,
+        string $printerGroupId
+    ): RequestInterface {
+        return $this->api->postShipmentsRequest(
             $this->getUserAgentHeader(),
             $requestModel,
             null,
             null,
             null,
             null,
-            ShipmentApi::contentTypes['postShipments'][0]
+            $this->resolveShipmentCreateContentType()
         )->withHeader('Accept', sprintf(self::DIRECT_PRINT_ACCEPT_TEMPLATE, $printerGroupId));
+    }
 
-        $response = $this->httpClient->sendRequest($request);
-        $decoded = json_decode((string) $response->getBody(), true);
+    private function resolveShipmentCreateContentType(): string
+    {
+        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
+            if (0 === strpos($contentType, 'application/vnd.shipment+json')) {
+                return $contentType;
+            }
+        }
 
-        return $this->parseIdsResponse($decoded);
+        throw new \RuntimeException('No shipment create content type configured in generated ShipmentApi client.');
     }
 
     /**
@@ -104,22 +122,49 @@ final class ShipmentPrintService
     /**
      * @return array<int, string|null>
      */
-    private function parseIdsResponse(?array $decoded): array
+    private function sendAndParseIdsResponse(RequestInterface $request): array
     {
-        if (! is_array($decoded) || ! isset($decoded['data']['ids']) || ! is_array($decoded['data']['ids'])) {
+        $response = $this->httpClient->sendRequest($request);
+
+        $body = (string) $response->getBody();
+        if ('' === $body) {
             return [];
         }
 
+        try {
+            $decoded = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
+            $responseModel = ObjectSerializer::deserialize(
+                $decoded,
+                ShipmentResponsesShipmentIds::class,
+                []
+            );
+        } catch (\JsonException | InvalidArgumentException $e) {
+            return [];
+        }
+
+        if (! $responseModel instanceof ShipmentResponsesShipmentIds || null === $responseModel->getData()) {
+            return [];
+        }
+
+        return $this->mapCreatedShipmentIds($responseModel->getData()->getIds() ?? []);
+    }
+
+    /**
+     * @param ShipmentResponsesShipmentIdsDataIdsInner[] $ids
+     *
+     * @return array<int, string|null>
+     */
+    private function mapCreatedShipmentIds(array $ids): array
+    {
         $mapping = [];
 
-        foreach ($decoded['data']['ids'] as $item) {
-            if (! is_array($item) || ! isset($item['id'])) {
+        foreach ($ids as $item) {
+            $shipmentId = $item->getId();
+            if (null === $shipmentId) {
                 continue;
             }
 
-            $mapping[(int) $item['id']] = isset($item['reference_identifier'])
-                ? (string) $item['reference_identifier']
-                : null;
+            $mapping[(int) $shipmentId] = $item->getReferenceIdentifier();
         }
 
         return $mapping;

--- a/src/Services/Shipment/ShipmentPrintService.php
+++ b/src/Services/Shipment/ShipmentPrintService.php
@@ -24,7 +24,8 @@ use Psr\Http\Message\RequestInterface;
  * Direct print flow for shipments.
  *
  * Uses hybrid approach (request builder + manual send) so we can override the Accept header
- * with the direct-print printer-group-id header.
+ * with the direct-print printer-group-id header. The response is still deserialized through
+ * the generated shipment ids model so the generated client remains the contract source of truth.
  *
  * @todo revert to direct generated API method once the direct-print Accept header
  *       is supported as a first-class parameter in the OpenAPI spec/client.
@@ -53,6 +54,9 @@ final class ShipmentPrintService
     /**
      * Create shipments and send labels directly to the given printer group.
      *
+     * Hybrid note: the only manual part is the custom Accept header that carries printer-group-id.
+     * Request and response contracts still come from the generated client.
+     *
      * @return array<int, string|null> Mapping shipment id => reference identifier.
      */
     public function print(ShipmentCollection $collection, string $printerGroupId): array
@@ -68,6 +72,9 @@ final class ShipmentPrintService
         return $this->sendAndParseIdsResponse($request);
     }
 
+    /**
+     * Build the generated shipment create request and then override Accept for direct print.
+     */
     private function createDirectPrintRequest(
         ShipmentPostShipmentsRequestV11 $requestModel,
         string $printerGroupId
@@ -83,6 +90,9 @@ final class ShipmentPrintService
         )->withHeader('Accept', sprintf(self::DIRECT_PRINT_ACCEPT_TEMPLATE, $printerGroupId));
     }
 
+    /**
+     * Resolve the generated shipment create content type by prefix instead of array index.
+     */
     private function resolveShipmentCreateContentType(): string
     {
         foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
@@ -120,30 +130,25 @@ final class ShipmentPrintService
     }
 
     /**
+     * Send the prepared hybrid request and deserialize it with the generated ids response model.
+     *
+     * We intentionally let parse and contract errors bubble so hybrid transport does not invent
+     * its own fallback error semantics.
+     *
      * @return array<int, string|null>
      */
     private function sendAndParseIdsResponse(RequestInterface $request): array
     {
         $response = $this->httpClient->sendRequest($request);
-
-        $body = (string) $response->getBody();
-        if ('' === $body) {
-            return [];
-        }
-
-        try {
-            $decoded = json_decode($body, false, 512, JSON_THROW_ON_ERROR);
-            $responseModel = ObjectSerializer::deserialize(
-                $decoded,
-                ShipmentResponsesShipmentIds::class,
-                []
-            );
-        } catch (\JsonException | InvalidArgumentException $e) {
-            return [];
-        }
+        $decoded = json_decode((string) $response->getBody(), false, 512, JSON_THROW_ON_ERROR);
+        $responseModel = ObjectSerializer::deserialize(
+            $decoded,
+            ShipmentResponsesShipmentIds::class,
+            []
+        );
 
         if (! $responseModel instanceof ShipmentResponsesShipmentIds || null === $responseModel->getData()) {
-            return [];
+            throw new InvalidArgumentException('Unexpected response type returned while parsing direct print response.');
         }
 
         return $this->mapCreatedShipmentIds($responseModel->getData()->getIds() ?? []);

--- a/src/Services/Shipment/ShipmentPrintService.php
+++ b/src/Services/Shipment/ShipmentPrintService.php
@@ -16,6 +16,7 @@ use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
+use MyParcelNL\Sdk\Services\CoreApi\Concerns\ResolvesPostShipmentsContentType;
 use MyParcelNL\Sdk\Services\Shipment\Concerns\EnsuresShipmentReferenceIds;
 use Psr\Http\Client\ClientInterface as PsrClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -34,6 +35,7 @@ final class ShipmentPrintService
 {
     use HasUserAgent;
     use EnsuresShipmentReferenceIds;
+    use ResolvesPostShipmentsContentType;
 
     private const DIRECT_PRINT_ACCEPT_TEMPLATE = 'application/vnd.shipment_label+json+print;printer-group-id=%s';
 
@@ -86,22 +88,8 @@ final class ShipmentPrintService
             null,
             null,
             null,
-            $this->resolveShipmentCreateContentType()
+            $this->resolvePostShipmentsContentType('application/vnd.shipment+json')
         )->withHeader('Accept', sprintf(self::DIRECT_PRINT_ACCEPT_TEMPLATE, $printerGroupId));
-    }
-
-    /**
-     * Resolve the generated shipment create content type by prefix instead of array index.
-     */
-    private function resolveShipmentCreateContentType(): string
-    {
-        foreach (ShipmentApi::contentTypes['postShipments'] as $contentType) {
-            if (0 === strpos($contentType, 'application/vnd.shipment+json')) {
-                return $contentType;
-            }
-        }
-
-        throw new \RuntimeException('No shipment create content type configured in generated ShipmentApi client.');
     }
 
     /**

--- a/test/Client/Generated/CoreApi/ShipmentApiPostShipmentsTest.php
+++ b/test/Client/Generated/CoreApi/ShipmentApiPostShipmentsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Client\Generated\CoreApi;
+
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Psr7\Response;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Configuration;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11Data;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentRequest;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+use Psr\Http\Message\RequestInterface;
+
+final class ShipmentApiPostShipmentsTest extends TestCase
+{
+    public function testPostShipmentsDeserializesMultiColloRegionsAsStrings(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('send')
+            ->with(
+                self::callback(function (RequestInterface $request): bool {
+                    self::assertSame('POST', $request->getMethod());
+                    self::assertSame('/shipments', $request->getUri()->getPath());
+
+                    return true;
+                }),
+                self::isType('array')
+            )
+            ->willReturn(new Response(200, [], json_encode([
+                'data' => [
+                    'shipments' => [[
+                        'id' => 123,
+                        'reference_identifier' => 'multi-collo-ref',
+                        'region' => 'NL',
+                        'secondary_shipments' => [[
+                            'id' => 124,
+                            'reference_identifier' => 'multi-collo-ref',
+                            'region' => 'NL',
+                        ]],
+                    ]],
+                ],
+            ], JSON_THROW_ON_ERROR)));
+
+        $config = new Configuration();
+        $config->setHost('https://api.myparcel.nl');
+        $config->setAccessToken('encoded_api_key');
+
+        $data = new ShipmentPostShipmentsRequestV11Data();
+        $data->setShipments([new ShipmentRequest()]);
+        $data->setUserAgent('SDK-Test/1.0');
+
+        $request = new ShipmentPostShipmentsRequestV11();
+        $request->setData($data);
+
+        $api = new ShipmentApi($client, $config);
+        $response = $api->postShipments('SDK-Test/1.0', $request);
+
+        $shipments = $response->getData()->getShipments();
+
+        self::assertCount(1, $shipments);
+        self::assertSame('NL', $shipments[0]->getRegion());
+        self::assertCount(1, $shipments[0]->getSecondaryShipments());
+        self::assertSame('NL', $shipments[0]->getSecondaryShipments()[0]->getRegion());
+    }
+
+    public function testPostShipmentsDeserializesEmptyPaymentStatusAsString(): void
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::once())
+            ->method('send')
+            ->with(
+                self::callback(function (RequestInterface $request): bool {
+                    self::assertSame('POST', $request->getMethod());
+                    self::assertSame('/shipments', $request->getUri()->getPath());
+
+                    return true;
+                }),
+                self::isType('array')
+            )
+            ->willReturn(new Response(200, [], json_encode([
+                'data' => [
+                    'shipments' => [[
+                        'id' => 123,
+                        'reference_identifier' => 'return-ref',
+                        'payment_status' => '',
+                    ]],
+                ],
+            ], JSON_THROW_ON_ERROR)));
+
+        $config = new Configuration();
+        $config->setHost('https://api.myparcel.nl');
+        $config->setAccessToken('encoded_api_key');
+
+        $data = new ShipmentPostShipmentsRequestV11Data();
+        $data->setShipments([new ShipmentRequest()]);
+        $data->setUserAgent('SDK-Test/1.0');
+
+        $request = new ShipmentPostShipmentsRequestV11();
+        $request->setData($data);
+
+        $api = new ShipmentApi($client, $config);
+        $response = $api->postShipments('SDK-Test/1.0', $request);
+
+        $shipments = $response->getData()->getShipments();
+
+        self::assertCount(1, $shipments);
+        self::assertSame('', $shipments[0]->getPaymentStatus());
+    }
+}

--- a/test/Services/Labels/ShipmentLabelsServiceTest.php
+++ b/test/Services/Labels/ShipmentLabelsServiceTest.php
@@ -176,7 +176,7 @@ final class ShipmentLabelsServiceTest extends TestCase
         $httpClient->shouldReceive('sendRequest')
             ->once()
             ->with(Mockery::on(static function (RequestInterface $request): bool {
-                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf+print');
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
             }))
             ->andReturn(new Response(200, [], json_encode([
                 'data' => [
@@ -192,6 +192,41 @@ final class ShipmentLabelsServiceTest extends TestCase
         $this->expectExceptionMessage('Received payment link instead of pdf. Check your MyParcel account status.');
 
         $service->setPdfOfLabels([101]);
+    }
+
+    public function testSetPdfOfLabelsStoresPdfBody(): void
+    {
+        $api = Mockery::mock(ShipmentApi::class);
+        $httpClient = Mockery::mock(ClientInterface::class);
+        $request = new Request('GET', 'https://api.myparcel.nl/shipment_labels/101?format=A4&positions=1;2;3;4');
+        $pdf = "%PDF-1.4\nfake-pdf";
+
+        $api->shouldReceive('getShipmentsLabelsRequest')
+            ->once()
+            ->with(
+                '101',
+                Mockery::type('string'),
+                'A4',
+                '1;2;3;4',
+                null,
+                null,
+                ShipmentApi::contentTypes['getShipmentsLabels'][0]
+            )
+            ->andReturn($request);
+
+        $httpClient->shouldReceive('sendRequest')
+            ->once()
+            ->with(Mockery::on(static function (RequestInterface $request): bool {
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
+            }))
+            ->andReturn(new Response(200, ['Content-Type' => 'application/pdf'], $pdf));
+
+        $service = new ShipmentLabelsService($this->getApiKey(), $api, $httpClient);
+
+        $result = $service->setPdfOfLabels([101]);
+
+        self::assertSame($pdf, $result);
+        self::assertSame($pdf, $service->getLabelPdf());
     }
 
     public function testSetPdfOfLabelsThrowsOnInvalidPdfResponse(): void
@@ -216,7 +251,7 @@ final class ShipmentLabelsServiceTest extends TestCase
         $httpClient->shouldReceive('sendRequest')
             ->once()
             ->with(Mockery::on(static function (RequestInterface $request): bool {
-                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf+print');
+                return ShipmentLabelsServiceTest::assertAcceptHeader($request, 'application/pdf');
             }))
             ->andReturn(new Response(200, [], 'not-a-pdf'));
 

--- a/test/Services/Returns/ReturnShipmentServiceTest.php
+++ b/test/Services/Returns/ReturnShipmentServiceTest.php
@@ -228,4 +228,29 @@ final class ReturnShipmentServiceTest extends TestCase
 
         self::assertSame([], $result);
     }
+
+    public function testCreateRelatedThrowsOnUnexpectedResponse(): void
+    {
+        $api = $this->createMock(ShipmentApi::class);
+        $api->expects(self::once())
+            ->method('postShipmentsRequest')
+            ->willReturn(new Request('POST', 'https://api.myparcel.nl/shipments'));
+
+        $httpClient = $this->createMock(PsrClientInterface::class);
+        $httpClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn(new Response(200, [], '{"error":"something"}'));
+
+        $service = new ReturnShipmentService($this->getApiKey(), $api, $httpClient);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unexpected response type returned while parsing return shipment response.');
+
+        $service->createRelated([[
+            'parent' => 1001,
+            'carrier' => 1,
+            'email' => 'test@example.com',
+            'name' => 'John Doe',
+        ]], false);
+    }
 }

--- a/test/Services/Returns/ReturnShipmentServiceTest.php
+++ b/test/Services/Returns/ReturnShipmentServiceTest.php
@@ -44,7 +44,7 @@ final class ReturnShipmentServiceTest extends TestCase
         $httpClient->expects(self::once())
             ->method('sendRequest')
             ->willReturn(new Response(200, [], json_encode([
-                'data' => ['ids' => []],
+                'data' => ['shipments' => []],
             ])));
 
         $service = new ReturnShipmentService(
@@ -76,7 +76,9 @@ final class ReturnShipmentServiceTest extends TestCase
                 self::isNull(),
                 self::isNull(),
                 self::isNull(),
-                self::identicalTo(ShipmentApi::contentTypes['postShipments'][2])
+                self::callback(static function (string $contentType): bool {
+                    return 0 === strpos($contentType, 'application/vnd.return_shipment+json');
+                })
             )
             ->willReturn($baseRequest);
 
@@ -93,7 +95,7 @@ final class ReturnShipmentServiceTest extends TestCase
             }))
             ->willReturn(new Response(200, [], json_encode([
                 'data' => [
-                    'ids' => [
+                    'shipments' => [
                         ['id' => 9001, 'reference_identifier' => 'ret-9001'],
                     ],
                 ],
@@ -138,7 +140,7 @@ final class ReturnShipmentServiceTest extends TestCase
         $httpClient->expects(self::once())
             ->method('sendRequest')
             ->willReturn(new Response(200, [], json_encode([
-                'data' => ['ids' => []],
+                'data' => ['shipments' => []],
             ])));
 
         $service = new ReturnShipmentService(
@@ -168,7 +170,9 @@ final class ReturnShipmentServiceTest extends TestCase
                 self::isNull(),
                 self::isNull(),
                 self::isNull(),
-                self::identicalTo(ShipmentApi::contentTypes['postShipments'][3])
+                self::callback(static function (string $contentType): bool {
+                    return 0 === strpos($contentType, 'application/vnd.unrelated_return_shipment+json');
+                })
             )
             ->willReturn($baseRequest);
 
@@ -184,7 +188,7 @@ final class ReturnShipmentServiceTest extends TestCase
             }))
             ->willReturn(new Response(200, [], json_encode([
                 'data' => [
-                    'ids' => [
+                    'shipments' => [
                         ['id' => 9101, 'reference_identifier' => 'unr-9101'],
                     ],
                 ],
@@ -200,7 +204,7 @@ final class ReturnShipmentServiceTest extends TestCase
         self::assertSame([9101 => 'unr-9101'], $result);
     }
 
-    public function testCreateRelatedReturnsEmptyMappingWhenResponseHasNoIds(): void
+    public function testCreateRelatedReturnsEmptyMappingWhenResponseHasNoShipments(): void
     {
         $api = $this->createMock(ShipmentApi::class);
         $api->expects(self::once())
@@ -211,7 +215,7 @@ final class ReturnShipmentServiceTest extends TestCase
         $httpClient->expects(self::once())
             ->method('sendRequest')
             ->willReturn(new Response(200, [], json_encode([
-                'data' => [],
+                'data' => ['shipments' => []],
             ])));
 
         $service = new ReturnShipmentService($this->getApiKey(), $api, $httpClient);

--- a/test/Services/Shipment/ShipmentCreateServiceTest.php
+++ b/test/Services/Shipment/ShipmentCreateServiceTest.php
@@ -6,14 +6,13 @@ namespace MyParcelNL\Sdk\Test\Services\Shipment;
 
 use InvalidArgumentException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\InlineObject;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentPackageTypeV2;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefShipmentReferenceIdentifier;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefTypesCarrierV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentDefsShipment;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11Data;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesShipmentIdsDataIdsInner;
-use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesShipmentLabelsData;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesPostShipmentsV12;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentResponsesPostShipmentsV12Data;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\Shipment\ShipmentCreateService;
@@ -80,7 +79,9 @@ final class ShipmentCreateServiceTest extends TestCase
                 self::identicalTo('1;2'),
                 self::isNull(),
                 self::isNull(),
-                self::identicalTo(ShipmentApi::contentTypes['postShipments'][0])
+                self::callback(static function (string $contentType): bool {
+                    return 0 === strpos($contentType, 'application/vnd.shipment+json');
+                })
             )
             ->willReturn($this->mockCreateResponse([
                 ['id' => 1001, 'reference_identifier' => 'order-1'],
@@ -124,7 +125,9 @@ final class ShipmentCreateServiceTest extends TestCase
                 self::isNull(),
                 self::isNull(),
                 self::isNull(),
-                self::identicalTo(ShipmentApi::contentTypes['postShipments'][0])
+                self::callback(static function (string $contentType): bool {
+                    return 0 === strpos($contentType, 'application/vnd.shipment+json');
+                })
             )
             ->willReturn($this->mockCreateResponse([
                 ['id' => 3001, 'reference_identifier' => 'order-enum'],
@@ -161,7 +164,9 @@ final class ShipmentCreateServiceTest extends TestCase
                 self::isNull(),
                 self::isNull(),
                 self::isNull(),
-                self::identicalTo(ShipmentApi::contentTypes['postShipments'][0])
+                self::callback(static function (string $contentType): bool {
+                    return 0 === strpos($contentType, 'application/vnd.shipment+json');
+                })
             )
             ->willReturnCallback(
                 fn () => $this->mockCreateResponse([
@@ -177,7 +182,7 @@ final class ShipmentCreateServiceTest extends TestCase
         self::assertSame([2001 => $shipment->getReferenceIdentifier()], $result);
     }
 
-    public function testCreateFallsBackToRequestReferenceWhenGeneratedReferenceIsWrapperObject(): void
+    public function testCreateFallsBackToRequestReferenceWhenResponseReferenceIdentifierIsNull(): void
     {
         $shipment = (new Shipment())->setReferenceIdentifier('order-wrapper-ref');
         $collection = new ShipmentCollection([$shipment]);
@@ -188,7 +193,7 @@ final class ShipmentCreateServiceTest extends TestCase
         $api->expects(self::once())
             ->method('postShipments')
             ->willReturn($this->mockCreateResponse([
-                ['id' => 7001, 'reference_identifier' => new RefShipmentReferenceIdentifier()],
+                ['id' => 7001, 'reference_identifier' => null],
             ]));
 
         $result = $service->create($collection);
@@ -199,21 +204,21 @@ final class ShipmentCreateServiceTest extends TestCase
     /**
      * @param array<int, array{id:int, reference_identifier:mixed}> $ids
      */
-    private function mockCreateResponse(array $ids): InlineObject
+    private function mockCreateResponse(array $ids): ShipmentResponsesPostShipmentsV12
     {
-        $idModels = array_map(static function (array $row): ShipmentResponsesShipmentIdsDataIdsInner {
-            $model = new ShipmentResponsesShipmentIdsDataIdsInner();
-            $model->setId((string) $row['id']);
+        $shipmentModels = array_map(static function (array $row): ShipmentDefsShipment {
+            $model = new ShipmentDefsShipment();
+            $model->setId($row['id']);
             $model->setReferenceIdentifier($row['reference_identifier']);
 
             return $model;
         }, $ids);
 
-        $labelsData = new ShipmentResponsesShipmentLabelsData();
-        $labelsData->setIds($idModels);
+        $data = new ShipmentResponsesPostShipmentsV12Data();
+        $data->setShipments($shipmentModels);
 
-        $response = new InlineObject();
-        $response->setData($labelsData);
+        $response = new ShipmentResponsesPostShipmentsV12();
+        $response->setData($data);
 
         return $response;
     }

--- a/test/Services/Shipment/ShipmentCreateServiceTest.php
+++ b/test/Services/Shipment/ShipmentCreateServiceTest.php
@@ -201,6 +201,75 @@ final class ShipmentCreateServiceTest extends TestCase
         self::assertSame([7001 => 'order-wrapper-ref'], $result);
     }
 
+    public function testCreateThrowsWhenResponseDataIsMissing(): void
+    {
+        $collection = new ShipmentCollection([
+            (new Shipment())->setReferenceIdentifier('order-missing-data'),
+        ]);
+
+        $api = $this->createMock(ShipmentApi::class);
+        $service = new ShipmentCreateService($this->getApiKey(), $api);
+
+        $api->expects(self::once())
+            ->method('postShipments')
+            ->willReturn(new ShipmentResponsesPostShipmentsV12());
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('ShipmentApi::postShipments() returned a response without data.');
+
+        $service->create($collection);
+    }
+
+    public function testCreateReturnsEmptyMappingWhenResponseHasNoShipments(): void
+    {
+        $collection = new ShipmentCollection([
+            (new Shipment())->setReferenceIdentifier('order-no-shipments'),
+        ]);
+
+        $api = $this->createMock(ShipmentApi::class);
+        $service = new ShipmentCreateService($this->getApiKey(), $api);
+
+        $data = new ShipmentResponsesPostShipmentsV12Data();
+        $response = new ShipmentResponsesPostShipmentsV12();
+        $response->setData($data);
+
+        $api->expects(self::once())
+            ->method('postShipments')
+            ->willReturn($response);
+
+        self::assertSame([], $service->create($collection));
+    }
+
+    public function testCreateSkipsShipmentsWithoutIdInResponse(): void
+    {
+        $collection = new ShipmentCollection([
+            (new Shipment())->setReferenceIdentifier('order-with-id'),
+            (new Shipment())->setReferenceIdentifier('order-without-id'),
+        ]);
+
+        $api = $this->createMock(ShipmentApi::class);
+        $service = new ShipmentCreateService($this->getApiKey(), $api);
+
+        $shipmentWithId = new ShipmentDefsShipment();
+        $shipmentWithId->setId(8001);
+        $shipmentWithId->setReferenceIdentifier('order-with-id');
+
+        $shipmentWithoutId = new ShipmentDefsShipment();
+        $shipmentWithoutId->setReferenceIdentifier('order-without-id');
+
+        $data = new ShipmentResponsesPostShipmentsV12Data();
+        $data->setShipments([$shipmentWithId, $shipmentWithoutId]);
+
+        $response = new ShipmentResponsesPostShipmentsV12();
+        $response->setData($data);
+
+        $api->expects(self::once())
+            ->method('postShipments')
+            ->willReturn($response);
+
+        self::assertSame([8001 => 'order-with-id'], $service->create($collection));
+    }
+
     /**
      * @param array<int, array{id:int, reference_identifier:mixed}> $ids
      */

--- a/test/Services/Shipment/ShipmentPrintServiceTest.php
+++ b/test/Services/Shipment/ShipmentPrintServiceTest.php
@@ -8,6 +8,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\ShipmentPostShipmentsRequestV11;
 use MyParcelNL\Sdk\Collection\ShipmentCollection;
 use MyParcelNL\Sdk\Model\Shipment\Shipment;
 use MyParcelNL\Sdk\Services\Shipment\ShipmentPrintService;
@@ -39,6 +40,17 @@ final class ShipmentPrintServiceTest extends TestCase
         $api = $this->createMock(ShipmentApi::class);
         $api->expects(self::once())
             ->method('postShipmentsRequest')
+            ->with(
+                self::isType('string'),
+                self::isInstanceOf(ShipmentPostShipmentsRequestV11::class),
+                self::isNull(),
+                self::isNull(),
+                self::isNull(),
+                self::isNull(),
+                self::callback(static function (string $contentType): bool {
+                    return 0 === strpos($contentType, 'application/vnd.shipment+json');
+                })
+            )
             ->willReturn(new Request('POST', 'https://api.myparcel.nl/shipments', [], '{}'));
 
         $capturedRequest = null;
@@ -52,6 +64,9 @@ final class ShipmentPrintServiceTest extends TestCase
                     'data' => [
                         'ids' => [
                             ['id' => 6001, 'reference_identifier' => 'order-1001'],
+                        ],
+                        'pdf' => [
+                            'url' => '/pdfs/test-print-job',
                         ],
                     ],
                 ]));

--- a/test/Services/Shipment/ShipmentPrintServiceTest.php
+++ b/test/Services/Shipment/ShipmentPrintServiceTest.php
@@ -112,7 +112,7 @@ final class ShipmentPrintServiceTest extends TestCase
         self::assertStringStartsWith('sdk_', $shipment->getReferenceIdentifier());
     }
 
-    public function testPrintReturnsEmptyArrayOnUnexpectedResponse(): void
+    public function testPrintThrowsOnUnexpectedResponse(): void
     {
         $api = $this->createMock(ShipmentApi::class);
         $api->method('postShipmentsRequest')
@@ -128,6 +128,9 @@ final class ShipmentPrintServiceTest extends TestCase
 
         $service = new ShipmentPrintService($this->getApiKey(), $api, $httpClient);
 
-        self::assertSame([], $service->print($collection, 'printer-group-1'));
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unexpected response type returned while parsing direct print response.');
+
+        $service->print($collection, 'printer-group-1');
     }
 }

--- a/test/Services/ShipmentServicesLiveSmokeTest.php
+++ b/test/Services/ShipmentServicesLiveSmokeTest.php
@@ -65,6 +65,28 @@ final class ShipmentServicesLiveSmokeTest extends TestCase
         self::assertSame($link, $labels->getLinkOfLabels());
     }
 
+    public function testSetPdfOfLabelsForCreatedShipment(): void
+    {
+        $collection = new ShipmentCollection();
+        $collection->push($this->createMinimalNlShipment('smoke-label-pdf-' . uniqid('', true)));
+
+        try {
+            $createService = new ShipmentCreateService($this->liveApiKey);
+            $created = $createService->create($collection);
+            $shipmentIds = array_keys($created);
+
+            $labels = new ShipmentLabelsService($this->liveApiKey);
+            $pdf = $labels->setPdfOfLabels($shipmentIds, false);
+        } catch (\Throwable $e) {
+            $this->handleLiveException($e);
+            return;
+        }
+
+        self::assertNotEmpty($pdf);
+        self::assertStringStartsWith('%PDF-', $pdf);
+        self::assertSame($pdf, $labels->getLabelPdf());
+    }
+
     public function testGeneratedLabelsRequestWithExplicitAcceptReturnsBody(): void
     {
         $collection = new ShipmentCollection();


### PR DESCRIPTION
This PR hardens the v11 shipment service wrappers against recent Core API spec/client changes.

Changes included:
- fix `ShipmentCreateService` to parse the current generated `postShipments` response shape
- fix return shipment creation to parse `data.shipments` instead of the old `data.ids`
- add type mappings for shipment `region` and `payment_status` codegen issues and regenerate the Core API client
- restore label PDF retrieval by using the correct `Accept: application/pdf`
- reduce wrapper fragility by resolving shipment content types by meaning instead of generated array index
- keep existing legacy/direct-print label flows intact where the generated client still does not model the contract correctly

INT-1499
