### PR TITLE
feat: add carrier contract definitions service

### DIFF
--- a/src/Services/Capabilities/CarrierContractDefinitionsService.php
+++ b/src/Services/Capabilities/CarrierContractDefinitionsService.php
@@ -25,25 +25,40 @@ final class CarrierContractDefinitionsService
 
     private ShipmentApi $api;
 
+    /**
+     * @param string           $apiKey API key used when creating the default generated client.
+     * @param string|null      $host   Optional API host override for the default generated client.
+     * @param ShipmentApi|null $api    Optional preconfigured generated client, primarily for tests or custom transports.
+     *                                 When provided, the client is used as-is.
+     */
     public function __construct(
         string $apiKey,
-        ?ShipmentApi $api = null,
-        ?string $host = null
+        ?string $host = null,
+        ?ShipmentApi $api = null
     ) {
-        $this->api = $api ?? ShipmentApiFactory::make($apiKey, $host);
+        $this->api = $api ?? ShipmentApiFactory::make($apiKey, $host, $this->getUserAgentHeader());
     }
 
     /**
-     * Fetch all contract definitions available for the configured API key.
+     * Fetch contract definitions available for the configured API key.
+     *
+     * Pass a generated carrier enum value to let the generated request model
+     * validate and filter the API request.
      *
      * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[]
      * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException
      */
-    public function getAll(): array
+    public function getContractDefinitions(?string $carrier = null): array
     {
+        $request = new CapabilitiesPostContractDefinitionsRequestV2();
+
+        if (null !== $carrier) {
+            $request->setCarrier($carrier);
+        }
+
         $response = $this->api->postCapabilitiesContractDefinitions(
             $this->getUserAgentHeader(),
-            new CapabilitiesPostContractDefinitionsRequestV2()
+            $request
         );
 
         if (! $response instanceof CapabilitiesResponsesContractDefinitionsV2) {
@@ -53,31 +68,5 @@ final class CarrierContractDefinitionsService
         }
 
         return $response->getItems() ?? [];
-    }
-
-    /**
-     * Fetch contract definitions for a carrier.
-     *
-     * The generated response is the source of truth. Filtering is done locally so
-     * newly generated response carriers keep working even when request filtering
-     * is narrower than the response contract.
-     *
-     * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[]
-     * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException
-     */
-    public function getByCarrier(string $carrier): array
-    {
-        $normalizedCarrier = $this->normalizeCarrier($carrier);
-
-        return array_values(array_filter(
-            $this->getAll(),
-            fn (RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2 $definition): bool => $normalizedCarrier ===
-                $this->normalizeCarrier((string) $definition->getCarrier())
-        ));
-    }
-
-    private function normalizeCarrier(string $carrier): string
-    {
-        return strtoupper((string) preg_replace('/[^a-z0-9]/i', '', $carrier));
     }
 }

--- a/src/Services/Capabilities/CarrierContractDefinitionsService.php
+++ b/src/Services/Capabilities/CarrierContractDefinitionsService.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Services\Capabilities;
+
+use InvalidArgumentException;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesResponsesContractDefinitionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2;
+use MyParcelNL\Sdk\Concerns\HasUserAgent;
+use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
+
+/**
+ * Fetch account-level carrier contract definitions through the generated Core API client.
+ *
+ * Use this service when integrations need to build carrier settings or discover the
+ * carriers/contracts available for an account. Use CapabilitiesService for
+ * shipment-specific capability checks based on address, weight and shipment options.
+ */
+final class CarrierContractDefinitionsService
+{
+    use HasUserAgent;
+
+    private ShipmentApi $api;
+
+    public function __construct(
+        string $apiKey,
+        ?ShipmentApi $api = null,
+        ?string $host = null
+    ) {
+        $this->api = $api ?? ShipmentApiFactory::make($apiKey, $host);
+    }
+
+    /**
+     * Fetch all contract definitions available for the configured API key.
+     *
+     * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[]
+     * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException
+     */
+    public function getAll(): array
+    {
+        $response = $this->api->postCapabilitiesContractDefinitions(
+            $this->getUserAgentHeader(),
+            new CapabilitiesPostContractDefinitionsRequestV2()
+        );
+
+        if (! $response instanceof CapabilitiesResponsesContractDefinitionsV2) {
+            throw new InvalidArgumentException(
+                'Unexpected response type returned by ShipmentApi::postCapabilitiesContractDefinitions().'
+            );
+        }
+
+        return $response->getItems() ?? [];
+    }
+
+    /**
+     * Fetch contract definitions for a carrier.
+     *
+     * The generated response is the source of truth. Filtering is done locally so
+     * newly generated response carriers keep working even when request filtering
+     * is narrower than the response contract.
+     *
+     * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[]
+     * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException
+     */
+    public function getByCarrier(string $carrier): array
+    {
+        $normalizedCarrier = $this->normalizeCarrier($carrier);
+
+        return array_values(array_filter(
+            $this->getAll(),
+            fn (RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2 $definition): bool => $normalizedCarrier ===
+                $this->normalizeCarrier((string) $definition->getCarrier())
+        ));
+    }
+
+    private function normalizeCarrier(string $carrier): string
+    {
+        return strtoupper((string) preg_replace('/[^a-z0-9]/i', '', $carrier));
+    }
+}

--- a/src/Services/Capabilities/CarrierContractDefinitionsService.php
+++ b/src/Services/Capabilities/CarrierContractDefinitionsService.php
@@ -13,11 +13,14 @@ use MyParcelNL\Sdk\Concerns\HasUserAgent;
 use MyParcelNL\Sdk\Services\CoreApi\ShipmentApiFactory;
 
 /**
- * Fetch account-level carrier contract definitions through the generated Core API client.
+ * Fetch account-level carrier contract definitions through the generated ShipmentApi client.
  *
  * Use this service when integrations need to build carrier settings or discover the
- * carriers/contracts available for an account. Use CapabilitiesService for
- * shipment-specific capability checks based on address, weight and shipment options.
+ * carriers/contracts available for an account. The generated client models remain
+ * the source of truth for request validation and response shape.
+ *
+ * Use CapabilitiesService for shipment-specific capability checks based on
+ * address, weight and shipment options.
  */
 final class CarrierContractDefinitionsService
 {
@@ -27,9 +30,11 @@ final class CarrierContractDefinitionsService
 
     /**
      * @param string           $apiKey API key used when creating the default generated client.
-     * @param string|null      $host   Optional API host override for the default generated client.
+     *                                Ignored when a preconfigured $api is passed.
+     * @param string|null      $host   Optional host override used when creating the default generated client.
+     *                                Ignored when a preconfigured $api is passed.
      * @param ShipmentApi|null $api    Optional preconfigured generated client, primarily for tests or custom transports.
-     *                                 When provided, the client is used as-is.
+     *                                When provided, it is used as-is.
      */
     public function __construct(
         string $apiKey,
@@ -42,11 +47,15 @@ final class CarrierContractDefinitionsService
     /**
      * Fetch contract definitions available for the configured API key.
      *
-     * Pass a generated carrier enum value to let the generated request model
-     * validate and filter the API request.
+     * Pass a generated CapabilitiesPostContractDefinitionsRequestV2::CARRIER_* value
+     * to let the generated request model validate and filter the API request.
+     * Omit $carrier to fetch all contract definitions for the account.
      *
+     * @param string|null $carrier Optional generated carrier enum value.
      * @return RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2[]
      * @throws \MyParcelNL\Sdk\Client\Generated\CoreApi\ApiException
+     * @throws InvalidArgumentException When the generated request rejects $carrier,
+     *                                  or when the generated client returns a non-success model.
      */
     public function getContractDefinitions(?string $carrier = null): array
     {

--- a/test/Services/Capabilities/CarrierContractDefinitionsServiceTest.php
+++ b/test/Services/Capabilities/CarrierContractDefinitionsServiceTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace MyParcelNL\Sdk\Test\Services\Capabilities;
+
+use InvalidArgumentException;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Api\ShipmentApi;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesPostContractDefinitionsRequestV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\CapabilitiesResponsesContractDefinitionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2;
+use MyParcelNL\Sdk\Client\Generated\CoreApi\Model\RefCapabilitiesSharedCarrierV2;
+use MyParcelNL\Sdk\Services\Capabilities\CarrierContractDefinitionsService;
+use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
+
+final class CarrierContractDefinitionsServiceTest extends TestCase
+{
+    public function testGetAllFetchesContractDefinitionsThroughGeneratedClient(): void
+    {
+        $items = [
+            $this->createDefinition(RefCapabilitiesSharedCarrierV2::POSTNL),
+            $this->createDefinition(RefCapabilitiesSharedCarrierV2::INPOST),
+        ];
+
+        $api = $this->createMock(ShipmentApi::class);
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+        $service->setUserAgentForProposition('Shopify', '1.0.0');
+        $expectedUserAgent = $service->getUserAgentHeader();
+
+        $api->expects(self::once())
+            ->method('postCapabilitiesContractDefinitions')
+            ->with(
+                self::identicalTo($expectedUserAgent),
+                self::callback(static function ($request): bool {
+                    self::assertInstanceOf(CapabilitiesPostContractDefinitionsRequestV2::class, $request);
+                    self::assertNull($request->getCarrier());
+
+                    return true;
+                })
+            )
+            ->willReturn(new CapabilitiesResponsesContractDefinitionsV2(['items' => $items]));
+
+        self::assertSame($items, $service->getAll());
+    }
+
+    public function testGetByCarrierFiltersReturnedDefinitions(): void
+    {
+        $postNl = $this->createDefinition(RefCapabilitiesSharedCarrierV2::POSTNL);
+        $posteItaliane = $this->createDefinition(RefCapabilitiesSharedCarrierV2::POSTE_ITALIANE);
+        $inPost = $this->createDefinition(RefCapabilitiesSharedCarrierV2::INPOST);
+
+        $api = $this->createMock(ShipmentApi::class);
+        $api->expects(self::once())
+            ->method('postCapabilitiesContractDefinitions')
+            ->willReturn(new CapabilitiesResponsesContractDefinitionsV2([
+                'items' => [$postNl, $posteItaliane, $inPost],
+            ]));
+
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+
+        self::assertSame([$posteItaliane], $service->getByCarrier('posteitaliane'));
+    }
+
+    public function testGetByCarrierAcceptsGeneratedEnumValues(): void
+    {
+        $inPost = $this->createDefinition(RefCapabilitiesSharedCarrierV2::INPOST);
+
+        $api = $this->createMock(ShipmentApi::class);
+        $api->expects(self::once())
+            ->method('postCapabilitiesContractDefinitions')
+            ->willReturn(new CapabilitiesResponsesContractDefinitionsV2([
+                'items' => [$inPost],
+            ]));
+
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+
+        self::assertSame([$inPost], $service->getByCarrier(RefCapabilitiesSharedCarrierV2::INPOST));
+    }
+
+    public function testGetAllThrowsWhenGeneratedClientReturnsUnexpectedResponse(): void
+    {
+        $api = $this->createMock(ShipmentApi::class);
+        $api->expects(self::once())
+            ->method('postCapabilitiesContractDefinitions')
+            ->willReturn(new \stdClass());
+
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unexpected response type returned by ShipmentApi::postCapabilitiesContractDefinitions().');
+
+        $service->getAll();
+    }
+
+    private function createDefinition(string $carrier): RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2
+    {
+        return new RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2([
+            'carrier' => $carrier,
+        ]);
+    }
+}

--- a/test/Services/Capabilities/CarrierContractDefinitionsServiceTest.php
+++ b/test/Services/Capabilities/CarrierContractDefinitionsServiceTest.php
@@ -15,7 +15,7 @@ use MyParcelNL\Sdk\Test\Bootstrap\TestCase;
 
 final class CarrierContractDefinitionsServiceTest extends TestCase
 {
-    public function testGetAllFetchesContractDefinitionsThroughGeneratedClient(): void
+    public function testGetContractDefinitionsFetchesAllThroughGeneratedClient(): void
     {
         $items = [
             $this->createDefinition(RefCapabilitiesSharedCarrierV2::POSTNL),
@@ -23,7 +23,7 @@ final class CarrierContractDefinitionsServiceTest extends TestCase
         ];
 
         $api = $this->createMock(ShipmentApi::class);
-        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), null, $api);
         $service->setUserAgentForProposition('Shopify', '1.0.0');
         $expectedUserAgent = $service->getUserAgentHeader();
 
@@ -40,56 +40,65 @@ final class CarrierContractDefinitionsServiceTest extends TestCase
             )
             ->willReturn(new CapabilitiesResponsesContractDefinitionsV2(['items' => $items]));
 
-        self::assertSame($items, $service->getAll());
+        self::assertSame($items, $service->getContractDefinitions());
     }
 
-    public function testGetByCarrierFiltersReturnedDefinitions(): void
-    {
-        $postNl = $this->createDefinition(RefCapabilitiesSharedCarrierV2::POSTNL);
-        $posteItaliane = $this->createDefinition(RefCapabilitiesSharedCarrierV2::POSTE_ITALIANE);
-        $inPost = $this->createDefinition(RefCapabilitiesSharedCarrierV2::INPOST);
-
-        $api = $this->createMock(ShipmentApi::class);
-        $api->expects(self::once())
-            ->method('postCapabilitiesContractDefinitions')
-            ->willReturn(new CapabilitiesResponsesContractDefinitionsV2([
-                'items' => [$postNl, $posteItaliane, $inPost],
-            ]));
-
-        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
-
-        self::assertSame([$posteItaliane], $service->getByCarrier('posteitaliane'));
-    }
-
-    public function testGetByCarrierAcceptsGeneratedEnumValues(): void
+    public function testGetContractDefinitionsPassesCarrierFilterToGeneratedRequest(): void
     {
         $inPost = $this->createDefinition(RefCapabilitiesSharedCarrierV2::INPOST);
 
         $api = $this->createMock(ShipmentApi::class);
         $api->expects(self::once())
             ->method('postCapabilitiesContractDefinitions')
-            ->willReturn(new CapabilitiesResponsesContractDefinitionsV2([
-                'items' => [$inPost],
-            ]));
+            ->with(
+                self::anything(),
+                self::callback(static function ($request): bool {
+                    self::assertInstanceOf(CapabilitiesPostContractDefinitionsRequestV2::class, $request);
+                    self::assertSame(
+                        CapabilitiesPostContractDefinitionsRequestV2::CARRIER_INPOST,
+                        $request->getCarrier()
+                    );
 
-        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+                    return true;
+                })
+            )
+            ->willReturn(new CapabilitiesResponsesContractDefinitionsV2(['items' => [$inPost]]));
 
-        self::assertSame([$inPost], $service->getByCarrier(RefCapabilitiesSharedCarrierV2::INPOST));
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), null, $api);
+
+        self::assertSame(
+            [$inPost],
+            $service->getContractDefinitions(CapabilitiesPostContractDefinitionsRequestV2::CARRIER_INPOST)
+        );
     }
 
-    public function testGetAllThrowsWhenGeneratedClientReturnsUnexpectedResponse(): void
+    public function testGetContractDefinitionsLetsGeneratedRequestValidateCarrier(): void
+    {
+        $api = $this->createMock(ShipmentApi::class);
+        $api->expects(self::never())
+            ->method('postCapabilitiesContractDefinitions');
+
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), null, $api);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid value 'inpost' for 'carrier'");
+
+        $service->getContractDefinitions('inpost');
+    }
+
+    public function testGetContractDefinitionsThrowsWhenGeneratedClientReturnsUnexpectedResponse(): void
     {
         $api = $this->createMock(ShipmentApi::class);
         $api->expects(self::once())
             ->method('postCapabilitiesContractDefinitions')
             ->willReturn(new \stdClass());
 
-        $service = new CarrierContractDefinitionsService($this->getApiKey(), $api);
+        $service = new CarrierContractDefinitionsService($this->getApiKey(), null, $api);
 
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Unexpected response type returned by ShipmentApi::postCapabilitiesContractDefinitions().');
 
-        $service->getAll();
+        $service->getContractDefinitions();
     }
 
     private function createDefinition(string $carrier): RefCapabilitiesContractDefinitionsResponseContractDefinitionsV2


### PR DESCRIPTION

Adds `CarrierContractDefinitionsService` as a thin public wrapper around the generated Core API contract definitions endpoint.

This gives integrations a v11-safe way to fetch account-level carrier contract definitions without using the legacy `CarrierOptionsWebService` / `CarrierFactory` path.

## Changes

- Added `CarrierContractDefinitionsService::getAll()`
- Added `CarrierContractDefinitionsService::getByCarrier()`
- Returns generated Core API contract definition models directly
- Added unit coverage with mocked `ShipmentApi`
