### PR TITLE
fix: consumer portal link mapping

### DIFF
--- a/openapi/coreapi.yaml
+++ b/openapi/coreapi.yaml
@@ -31,6 +31,10 @@ typeMappings:
   # @todo remove when upstream spec fixes reference_identifier union type
   # The union ['null','integer','string'] generates an empty wrapper model that loses data.
   RefShipmentReferenceIdentifier: string
+  # @todo remove when upstream spec/codegen fixes link_consumer_portal oneOf(uri | empty-string)
+  # The current codegen produces empty wrapper models that lose the actual URL.
+  ShipmentDefsShipmentLinkConsumerPortal: string
+  ShipmentDefsShipmentPropertiesLinkConsumerPortal: string
   # @todo remove when upstream spec/codegen fixes region oneOf(string pattern | enum)
   # The current codegen produces unusable model wrappers/enums for shipment resource regions.
   ShipmentDefsShipmentRegion: string


### PR DESCRIPTION
The generator currently turns `link_consumer_portal` into empty wrapper models because of the `oneOf` schema. This is a known/recurring issue (see existing mappings).  This maps those fields to `string`, so `getLinkConsumerPortal()` returns the URL.