### PR TITLE
ci: run tests on dependabot PRs

### DIFF
--- a/.github/workflows/--test.yml
+++ b/.github/workflows/--test.yml
@@ -14,16 +14,19 @@ jobs:
       contents: read
       packages: write
     steps:
+      # Dependabot PRs cannot access Actions secrets, so skip the app credentials for them.
+      # The test image is public and the tests only need to check out the PR, which works
+      # with the default GITHUB_TOKEN.
       - uses: myparcelnl/actions/setup-app-credentials@v5
+        if: github.actor != 'dependabot[bot]'
         id: credentials
         with:
           app-id: ${{ secrets.MYPARCEL_APP_ID }}
           private-key: ${{ secrets.MYPARCEL_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v6
-        if: github.actor != 'dependabot[bot]'
         with:
-          token: ${{ steps.credentials.outputs.token }}
+          token: ${{ steps.credentials.outputs.token || github.token }}
 
       - name: 'Handle coverage cache'
         if: github.actor != 'dependabot[bot]'
@@ -34,13 +37,11 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.php-version }}-coverage-${{ hashFiles('./src/**', './test/**') }}
 
       - uses: myparcelnl/actions/pull-docker-image@v5
-        if: github.actor != 'dependabot[bot]'
         id: docker
         with:
           image: ghcr.io/myparcelnl/php-xd:${{ matrix.php-version }}
 
       - name: 'Install composer dependencies'
-        if: github.actor != 'dependabot[bot]'
         run: |
           docker run \
             --volume $PWD:/app \


### PR DESCRIPTION
## Problem

Dependabot PRs were failing on every matrix test job:

```
docker run \
Unable to find image 'vendor/bin/phpunit:latest'
docker: pull access denied for vendor/bin/phpunit ...
```

Since #543 refactored the test steps, the `pull-docker-image` step still skipped for dependabot but the `Run tests` step no longer did. With the image step skipped, `steps.docker.outputs.image` was empty, so `docker run ... vendor/bin/phpunit` was read as the image name.

## Fix

Dependabot PRs can't read Actions secrets, but the tests don't need them:
- the `php-xd` image is public (anonymous `docker pull` returns 200), so no `docker login`/token is required
- the PR can be checked out with the default `GITHUB_TOKEN`

So I only gate the `setup-app-credentials` step to non-dependabot and let the docker steps run for everyone. Checkout falls back to `github.token` when the app token isn't available.

Result: dependabot now runs the full phpunit suite across all PHP versions. Coverage upload stays non-dependabot-only. Non-dependabot behaviour is unchanged (app token still used for checkout, 8.4 still runs coverage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)