### PR TITLE
ci: check out the repo on dependabot PRs

### DIFF
--- a/.github/workflows/--test.yml
+++ b/.github/workflows/--test.yml
@@ -25,7 +25,6 @@ jobs:
           private-key: ${{ secrets.MYPARCEL_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@v7
-        if: github.actor != 'dependabot[bot]'
         with:
           token: ${{ steps.credentials.outputs.token || github.token }}
 


### PR DESCRIPTION
Removes the dependabot guard from the checkout step, so the tests run against the PR contents instead of an empty workspace.

#627 removed this guard and added the `${{ steps.credentials.outputs.token || github.token }}` fallback that replaces it. The merge in #629 kept the guard while it resolved a conflict with the actions/checkout v6 to v7 bump, so every dependabot job has failed on "Composer could not find a composer.json file in /app" since then.

setup-app-credentials keeps its guard, because dependabot cannot read Actions secrets. The coverage upload stays behind run-coverage.

Refs #627